### PR TITLE
Add home navigation link and i18n

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
         <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
       </button>
       <nav class="topnav" id="topnav">
+        <a href="index.html" data-i18n="nav.home">Accueil</a>
         <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
         <a href="localisation.html" data-i18n="nav.location">Localisation</a>
         <a href="stay.html" data-i18n="nav.stay">Hébergements</a>
@@ -103,7 +104,7 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
-          nav: { wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
         },
@@ -113,9 +114,19 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
-          nav: { wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
+        },
+        en: {
+          date: '08 August 2026 · Castello Marchione',
+          cta: 'Confirm attendance',
+          wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
+          location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
+          stay: { title: 'Where to stay?'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', rsvp: 'RSVP' },
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
+          footer: 'Made with love and some lemons 🍋'
         }
       };
 
@@ -134,6 +145,14 @@
       document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>applyTranslations(btn.dataset.lang)));
 
       applyTranslations('fr');
+
+      function highlightActiveLink(){
+        const current = location.pathname.split('/').pop() || 'index.html';
+        document.querySelectorAll('nav.topnav a').forEach(a=>{
+          a.classList.toggle('active', a.getAttribute('href')===current);
+        });
+      }
+      highlightActiveLink();
 
       // Hamburger toggle (mobile)
       const burger = document.querySelector('.hamburger');

--- a/localisation.html
+++ b/localisation.html
@@ -51,6 +51,7 @@
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
     </button>
     <nav class="topnav" id="topnav">
+      <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
       <a href="localisation.html" data-i18n="nav.location">Localisation</a>
       <a href="stay.html" data-i18n="nav.stay">Hébergements</a>
@@ -74,7 +75,7 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
-          nav: { wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
         },
@@ -84,9 +85,19 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
-          nav: { wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
+        },
+        en: {
+          date: '08 August 2026 · Castello Marchione',
+          cta: 'Confirm attendance',
+          wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
+          location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
+          stay: { title: 'Where to stay?'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', rsvp: 'RSVP' },
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
+          footer: 'Made with love and some lemons 🍋'
         }
       };
       function applyTranslations(lang){
@@ -102,6 +113,15 @@
       }
       document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>applyTranslations(btn.dataset.lang)));
       applyTranslations('fr');
+
+      function highlightActiveLink(){
+        const current = location.pathname.split('/').pop() || 'index.html';
+        document.querySelectorAll('nav.topnav a').forEach(a=>{
+          a.classList.toggle('active', a.getAttribute('href')===current);
+        });
+      }
+      highlightActiveLink();
+
       const burger = document.querySelector('.hamburger');
       const topnav = document.getElementById('topnav');
       if (burger && topnav){

--- a/rsvp.html
+++ b/rsvp.html
@@ -50,6 +50,7 @@
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
     </button>
     <nav class="topnav" id="topnav">
+      <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
       <a href="localisation.html" data-i18n="nav.location">Localisation</a>
       <a href="stay.html" data-i18n="nav.stay">Hébergements</a>
@@ -73,7 +74,7 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
-          nav: { wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
         },
@@ -83,9 +84,19 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
-          nav: { wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
+        },
+        en: {
+          date: '08 August 2026 · Castello Marchione',
+          cta: 'Confirm attendance',
+          wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
+          location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
+          stay: { title: 'Where to stay?'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', rsvp: 'RSVP' },
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
+          footer: 'Made with love and some lemons 🍋'
         }
       };
       function applyTranslations(lang){
@@ -101,6 +112,15 @@
       }
       document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>applyTranslations(btn.dataset.lang)));
       applyTranslations('fr');
+
+      function highlightActiveLink(){
+        const current = location.pathname.split('/').pop() || 'index.html';
+        document.querySelectorAll('nav.topnav a').forEach(a=>{
+          a.classList.toggle('active', a.getAttribute('href')===current);
+        });
+      }
+      highlightActiveLink();
+
       const burger = document.querySelector('.hamburger');
       const topnav = document.getElementById('topnav');
       if (burger && topnav){

--- a/stay.html
+++ b/stay.html
@@ -52,6 +52,7 @@
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
     </button>
     <nav class="topnav" id="topnav">
+      <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
       <a href="localisation.html" data-i18n="nav.location">Localisation</a>
       <a href="stay.html" data-i18n="nav.stay">Hébergements</a>
@@ -78,7 +79,7 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
-          nav: { wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
         },
@@ -88,9 +89,19 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
-          nav: { wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
+        },
+        en: {
+          date: '08 August 2026 · Castello Marchione',
+          cta: 'Confirm attendance',
+          wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
+          location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
+          stay: { title: 'Where to stay?'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', rsvp: 'RSVP' },
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
+          footer: 'Made with love and some lemons 🍋'
         }
       };
       function applyTranslations(lang){
@@ -106,6 +117,15 @@
       }
       document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>applyTranslations(btn.dataset.lang)));
       applyTranslations('fr');
+
+      function highlightActiveLink(){
+        const current = location.pathname.split('/').pop() || 'index.html';
+        document.querySelectorAll('nav.topnav a').forEach(a=>{
+          a.classList.toggle('active', a.getAttribute('href')===current);
+        });
+      }
+      highlightActiveLink();
+
       const burger = document.querySelector('.hamburger');
       const topnav = document.getElementById('topnav');
       if (burger && topnav){

--- a/wedding.html
+++ b/wedding.html
@@ -52,6 +52,7 @@
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
     </button>
     <nav class="topnav" id="topnav">
+      <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
       <a href="localisation.html" data-i18n="nav.location">Localisation</a>
       <a href="stay.html" data-i18n="nav.stay">Hébergements</a>
@@ -79,7 +80,7 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
-          nav: { wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
         },
@@ -89,9 +90,19 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
-          nav: { wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
+        },
+        en: {
+          date: '08 August 2026 · Castello Marchione',
+          cta: 'Confirm attendance',
+          wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
+          location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
+          stay: { title: 'Where to stay?'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', rsvp: 'RSVP' },
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
+          footer: 'Made with love and some lemons 🍋'
         }
       };
       function applyTranslations(lang){
@@ -107,6 +118,15 @@
       }
       document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>applyTranslations(btn.dataset.lang)));
       applyTranslations('fr');
+
+      function highlightActiveLink(){
+        const current = location.pathname.split('/').pop() || 'index.html';
+        document.querySelectorAll('nav.topnav a').forEach(a=>{
+          a.classList.toggle('active', a.getAttribute('href')===current);
+        });
+      }
+      highlightActiveLink();
+
       const burger = document.querySelector('.hamburger');
       const topnav = document.getElementById('topnav');
       if (burger && topnav){


### PR DESCRIPTION
## Summary
- Add Home link to navigation on all pages
- Extend i18n dictionaries with nav.home translations in FR/IT/EN and include English locale
- Highlight active navigation link for current page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59ad769c8832c8bba79e14b1eeca6