### PR TITLE
feat: ajouter section informations

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,6 +92,13 @@
       </div>
     </header>
 
+    <main>
+      <section id="informations">
+        <h2 data-i18n="info.title">Informations</h2>
+        <p data-i18n="info.text">Les détails pratiques seront ajoutés prochainement.</p>
+      </section>
+    </main>
+
     <footer>
       <p data-i18n="footer">Fait avec amour et quelques citrons 🍋</p>
     </footer>
@@ -104,6 +111,7 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
+          info: { title: 'Informations', text: 'Les détails pratiques seront ajoutés prochainement.' },
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
@@ -114,6 +122,7 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
+          info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
@@ -124,6 +133,7 @@
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           stay: { title: 'Where to stay?'},
+          info: { title: 'Information', text: 'Practical details will be added soon.' },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
           footer: 'Made with love and some lemons 🍋'


### PR DESCRIPTION
## Summary
- add main information section on homepage
- localize section content for French, Italian, and English

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b3703af4832c8d823845f868a866