### PR TITLE
Add dedicated information page and update navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
         <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
         <a href="localisation.html" data-i18n="nav.location">Localisation</a>
         <a href="stay.html" data-i18n="nav.stay">Hébergements</a>
+        <a href="info.html" data-i18n="nav.info">Informations</a>
         <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
       </nav>
       <div class="hero-content">
@@ -92,13 +93,7 @@
       </div>
     </header>
 
-    <main>
-      <section id="informations">
-        <h2 data-i18n="info.title">Informations</h2>
-        <p data-i18n="info.text">Les détails pratiques seront ajoutés prochainement.</p>
-      </section>
-    </main>
-
+    
     <footer>
       <p data-i18n="footer">Fait avec amour et quelques citrons 🍋</p>
     </footer>
@@ -112,7 +107,7 @@
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
           info: { title: 'Informations', text: 'Les détails pratiques seront ajoutés prochainement.' },
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
         },
@@ -123,7 +118,7 @@
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
           info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
         },
@@ -134,7 +129,7 @@
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           stay: { title: 'Where to stay?'},
           info: { title: 'Information', text: 'Practical details will be added soon.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
           footer: 'Made with love and some lemons 🍋'
         }

--- a/info.html
+++ b/info.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Wedding — Fidalma & Ilyes</title>
+    <title>Informations — Fidalma & Ilyes</title>
     <link rel="icon" type="image/svg+xml" href="olivier.svg?v=1" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -60,14 +60,9 @@
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
     </nav>
     <main>
-      <section id="wedding">
-        <h2 data-i18n="wedding.title">Wedding — Déroulé</h2>
-        <ul>
-          <li data-i18n="wedding.ceremony">17h00 : Cérémonie</li>
-          <li data-i18n="wedding.aperitivo">18h00 : Aperitivo</li>
-          <li data-i18n="wedding.dinner">20h00 : Dîner</li>
-          <li data-i18n="wedding.party">23h00 : Festa & DJ set</li>
-        </ul>
+      <section id="info">
+        <h2 data-i18n="info.title">Informations</h2>
+        <p data-i18n="info.text">Les détails pratiques seront ajoutés prochainement.</p>
       </section>
     </main>
     <footer>
@@ -81,6 +76,7 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
+          info: { title: 'Informations', text: 'Les détails pratiques seront ajoutés prochainement.' },
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
@@ -91,6 +87,7 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
+          info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
@@ -101,6 +98,7 @@
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           stay: { title: 'Where to stay?'},
+          info: { title: 'Information', text: 'Practical details will be added soon.' },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
           footer: 'Made with love and some lemons 🍋'

--- a/localisation.html
+++ b/localisation.html
@@ -55,6 +55,7 @@
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
       <a href="localisation.html" data-i18n="nav.location">Localisation</a>
       <a href="stay.html" data-i18n="nav.stay">Hébergements</a>
+      <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
     </nav>
     <main>
@@ -75,7 +76,7 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
         },
@@ -85,7 +86,7 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
         },
@@ -95,7 +96,7 @@
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           stay: { title: 'Where to stay?'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
           footer: 'Made with love and some lemons 🍋'
         }

--- a/rsvp.html
+++ b/rsvp.html
@@ -54,6 +54,7 @@
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
       <a href="localisation.html" data-i18n="nav.location">Localisation</a>
       <a href="stay.html" data-i18n="nav.stay">Hébergements</a>
+      <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
     </nav>
     <main>
@@ -74,7 +75,7 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
         },
@@ -84,7 +85,7 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
         },
@@ -94,7 +95,7 @@
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           stay: { title: 'Where to stay?'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
           footer: 'Made with love and some lemons 🍋'
         }

--- a/stay.html
+++ b/stay.html
@@ -56,6 +56,7 @@
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
       <a href="localisation.html" data-i18n="nav.location">Localisation</a>
       <a href="stay.html" data-i18n="nav.stay">Hébergements</a>
+      <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
     </nav>
     <main>
@@ -79,7 +80,7 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
           footer: 'Fait avec amour et quelques citrons 🍋'
         },
@@ -89,7 +90,7 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
           footer: 'Fatto con amore e qualche limone 🍋'
         },
@@ -99,7 +100,7 @@
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           stay: { title: 'Where to stay?'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
           footer: 'Made with love and some lemons 🍋'
         }


### PR DESCRIPTION
## Summary
- Create `info.html` page for practical wedding information with translations
- Link the new page in the top navigation across all pages
- Remove placeholder information section from home page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b5be1800832c83a7262906799c50