### PR TITLE
Remove footer phrase from pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,6 @@
       ul{list-style:none;padding-left:0;font-size:18px;}
       ul li{padding:6px 0;}
       iframe.map{width:100%;aspect-ratio:16/9;border:0;border-radius:12px;box-shadow:0 6px 16px rgba(0,0,0,.1);}
-      footer{text-align:center;padding:40px 0;font-size:14px;color:rgba(0,0,0,.6);}
       /* === Mobile hamburger menu === */
       .hamburger{display:none;}
       @media (max-width:768px){
@@ -95,9 +94,6 @@
     </header>
 
     
-    <footer>
-      <p data-i18n="footer">Fait avec amour et quelques citrons 🍋</p>
-    </footer>
 
     <script>
       const I18N = {
@@ -109,8 +105,7 @@
           stay: { title: 'Où dormir ?'},
           info: { title: 'Informations', text: 'Les détails pratiques seront ajoutés prochainement.' },
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
-          footer: 'Fait avec amour et quelques citrons 🍋'
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
@@ -120,8 +115,7 @@
           stay: { title: 'Dove dormire?'},
           info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
-          footer: 'Fatto con amore e qualche limone 🍋'
+          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -131,8 +125,7 @@
           stay: { title: 'Where to stay?'},
           info: { title: 'Information', text: 'Practical details will be added soon.' },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
-          footer: 'Made with love and some lemons 🍋'
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
         }
       };
 

--- a/info.html
+++ b/info.html
@@ -31,7 +31,6 @@
       h2{font-family:'Great Vibes',cursive;font-size:40px;color:var(--accent);margin-bottom:20px;}
       ul{list-style:none;padding-left:0;font-size:18px;}
       ul li{padding:6px 0;}
-      footer{text-align:center;padding:40px 0;font-size:14px;color:rgba(0,0,0,.6);}
       .hamburger{display:none;}
       @media (max-width:768px){
         .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:10px; border:2px solid #fff; background:rgba(255,255,255,.2); color:#fff; cursor:pointer;}
@@ -65,9 +64,6 @@
         <p data-i18n="info.text">Les détails pratiques seront ajoutés prochainement.</p>
       </section>
     </main>
-    <footer>
-      <p data-i18n="footer">Fait avec amour et quelques citrons 🍋</p>
-    </footer>
     <script>
       const I18N = {
         fr: {
@@ -78,8 +74,7 @@
           stay: { title: 'Où dormir ?'},
           info: { title: 'Informations', text: 'Les détails pratiques seront ajoutés prochainement.' },
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
-          footer: 'Fait avec amour et quelques citrons 🍋'
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
@@ -89,8 +84,7 @@
           stay: { title: 'Dove dormire?'},
           info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
-          footer: 'Fatto con amore e qualche limone 🍋'
+          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -100,8 +94,7 @@
           stay: { title: 'Where to stay?'},
           info: { title: 'Information', text: 'Practical details will be added soon.' },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
-          footer: 'Made with love and some lemons 🍋'
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
         }
       };
       function applyTranslations(lang){

--- a/localisation.html
+++ b/localisation.html
@@ -30,7 +30,6 @@
       section{text-align:center;}
       h2{font-family:'Great Vibes',cursive;font-size:40px;color:var(--accent);margin-bottom:20px;}
       iframe.map{width:100%;aspect-ratio:16/9;border:0;border-radius:12px;box-shadow:0 6px 16px rgba(0,0,0,.1);}
-      footer{text-align:center;padding:40px 0;font-size:14px;color:rgba(0,0,0,.6);}
       .hamburger{display:none;}
       @media (max-width:768px){
         .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:10px; border:2px solid #000; background:rgba(0,0,0,.05); color:#000; cursor:pointer;}
@@ -66,9 +65,6 @@
         <p data-i18n="location.text">Castello Marchione, Conversano, Italie</p>
       </section>
     </main>
-    <footer>
-      <p data-i18n="footer">Fait avec amour et quelques citrons 🍋</p>
-    </footer>
     <script>
       const I18N = {
         fr: {
@@ -78,8 +74,7 @@
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
-          footer: 'Fait avec amour et quelques citrons 🍋'
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
@@ -88,8 +83,7 @@
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
           nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
-          footer: 'Fatto con amore e qualche limone 🍋'
+          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -98,8 +92,7 @@
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           stay: { title: 'Where to stay?'},
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
-          footer: 'Made with love and some lemons 🍋'
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
         }
       };
       function applyTranslations(lang){

--- a/rsvp.html
+++ b/rsvp.html
@@ -29,7 +29,6 @@
       main{padding:80px 20px;max-width:900px;margin:0 auto;}
       section{text-align:center;}
       h2{font-family:'Great Vibes',cursive;font-size:40px;color:var(--accent);margin-bottom:20px;}
-      footer{text-align:center;padding:40px 0;font-size:14px;color:rgba(0,0,0,.6);}
       .hamburger{display:none;}
       @media (max-width:768px){
         .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:10px; border:2px solid #000; background:rgba(0,0,0,.05); color:#000; cursor:pointer;}
@@ -65,9 +64,6 @@
         <a href="#" class="cta" target="_blank" data-i18n="rsvp.cta">Répondre au formulaire</a>
       </section>
     </main>
-    <footer>
-      <p data-i18n="footer">Fait avec amour et quelques citrons 🍋</p>
-    </footer>
     <script>
       const I18N = {
         fr: {
@@ -77,8 +73,7 @@
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
-          footer: 'Fait avec amour et quelques citrons 🍋'
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
@@ -87,8 +82,7 @@
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
           nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
-          footer: 'Fatto con amore e qualche limone 🍋'
+          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -97,8 +91,7 @@
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           stay: { title: 'Where to stay?'},
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
-          footer: 'Made with love and some lemons 🍋'
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
         }
       };
       function applyTranslations(lang){

--- a/stay.html
+++ b/stay.html
@@ -31,7 +31,6 @@
       h2{font-family:'Great Vibes',cursive;font-size:40px;color:var(--accent);margin-bottom:20px;}
       ul{list-style:none;padding-left:0;font-size:18px;}
       ul li{padding:6px 0;}
-      footer{text-align:center;padding:40px 0;font-size:14px;color:rgba(0,0,0,.6);}
       .hamburger{display:none;}
       @media (max-width:768px){
         .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:10px; border:2px solid #000; background:rgba(0,0,0,.05); color:#000; cursor:pointer;}
@@ -70,9 +69,6 @@
         </ul>
       </section>
     </main>
-    <footer>
-      <p data-i18n="footer">Fait avec amour et quelques citrons 🍋</p>
-    </footer>
     <script>
       const I18N = {
         fr: {
@@ -82,8 +78,7 @@
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
-          footer: 'Fait avec amour et quelques citrons 🍋'
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
@@ -92,8 +87,7 @@
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
           nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
-          footer: 'Fatto con amore e qualche limone 🍋'
+          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -102,8 +96,7 @@
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           stay: { title: 'Where to stay?'},
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
-          footer: 'Made with love and some lemons 🍋'
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
         }
       };
       function applyTranslations(lang){

--- a/wedding.html
+++ b/wedding.html
@@ -31,7 +31,6 @@
       h2{font-family:'Great Vibes',cursive;font-size:40px;color:var(--accent);margin-bottom:20px;}
       ul{list-style:none;padding-left:0;font-size:18px;}
       ul li{padding:6px 0;}
-      footer{text-align:center;padding:40px 0;font-size:14px;color:rgba(0,0,0,.6);}
       .hamburger{display:none;}
       @media (max-width:768px){
         .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:10px; border:2px solid #000; background:rgba(0,0,0,.05); color:#000; cursor:pointer;}
@@ -71,9 +70,6 @@
         </ul>
       </section>
     </main>
-    <footer>
-      <p data-i18n="footer">Fait avec amour et quelques citrons 🍋</p>
-    </footer>
     <script>
       const I18N = {
         fr: {
@@ -83,8 +79,7 @@
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           stay: { title: 'Où dormir ?'},
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', stay: 'Hébergements', info: 'Informations', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'},
-          footer: 'Fait avec amour et quelques citrons 🍋'
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
@@ -93,8 +88,7 @@
           location: { title: 'Località', text: 'Castello Marchione, Conversano, Italia'},
           stay: { title: 'Dove dormire?'},
           nav: { home: 'Home', wedding: 'Wedding', location: 'Località', stay: 'Alloggi', info: 'Informazioni', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'},
-          footer: 'Fatto con amore e qualche limone 🍋'
+          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -103,8 +97,7 @@
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           stay: { title: 'Where to stay?'},
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', stay: 'Stay', info: 'Info', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'},
-          footer: 'Made with love and some lemons 🍋'
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
         }
       };
       function applyTranslations(lang){


### PR DESCRIPTION
## Summary
- remove the "Fait avec amour et quelques citrons" footer from all site pages
- drop unused `footer` entries from i18n dictionaries

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b8dc5d5c832c87ff6283c634e743