### PR TITLE
Use dark buttons on info section

### DIFF
--- a/info.html
+++ b/info.html
@@ -19,12 +19,12 @@
       *{box-sizing:border-box;}
       body{margin:0;font-family:'Montserrat',sans-serif;color:var(--text);background:var(--background);}
       .lang-switch{position:absolute;top:20px;left:20px;z-index:3;}
-      .lang-switch button{margin-right:6px;border:1px solid #000;background:#000;color:#fff;padding:6px 10px;border-radius:999px;cursor:pointer;font-weight:600;}
-      .lang-switch button.active{background:#000;color:#fff;border-color:#000;}
+      .lang-switch button{margin-right:6px;border:1px solid #000;background:rgba(0,0,0,.05);color:#000;padding:6px 10px;border-radius:999px;cursor:pointer;font-weight:600;}
+      .lang-switch button.active{background:var(--primary);color:var(--text);border-color:transparent;}
       nav.topnav{position:absolute;top:20px;right:20px;display:flex;gap:20px;z-index:3;}
-      nav.topnav a{color:#fff;text-decoration:none;font-weight:500;transition:.3s;}
+      nav.topnav a{color:#000;text-decoration:none;font-weight:500;transition:.3s;}
       nav.topnav a:hover,nav.topnav a.active{border-bottom:2px solid var(--primary);}
-      nav.topnav .rsvp-btn{border:2px solid #fff;padding:6px 14px;border-radius:4px;}
+      nav.topnav .rsvp-btn{border:2px solid #000;padding:6px 14px;border-radius:4px;}
       nav.topnav .rsvp-btn:hover{background:var(--primary);color:var(--text);border-color:var(--primary);}
       main{padding:80px 20px;max-width:900px;margin:0 auto;}
       section{text-align:center;}
@@ -33,7 +33,7 @@
       ul li{padding:6px 0;}
       .hamburger{display:none;}
       @media (max-width:768px){
-        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:10px; border:2px solid #000; background:#000; color:#fff; cursor:pointer;}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:10px; border:2px solid #000; background:rgba(0,0,0,.05); color:#000; cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--primary); outline-offset:2px;}
         nav.topnav{display:none; position:absolute; top:70px; right:10px; flex-direction:column; gap:12px; background:rgba(252,251,243,.96); padding:12px; border-radius:12px; box-shadow:0 8px 24px rgba(0,0,0,.18); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
         nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}


### PR DESCRIPTION
## Summary
- restyle information page buttons to use black text, matching other sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bd3af6a8832cb55dc06b407a17d4