### PR TITLE
Update Italian RSVP wording and set confirmation deadline to June 30, 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           info: { title: 'Informations', text: 'Les détails pratiques seront ajoutés prochainement.' },
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
@@ -160,8 +160,8 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Localizzazione', text: 'Castello Marchione, Conversano, Italia'},
           info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
+          rsvp: { title: 'confirma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -171,7 +171,7 @@
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           info: { title: 'Information', text: 'Practical details will be added soon.' },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };
 

--- a/info.html
+++ b/info.html
@@ -77,7 +77,7 @@
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           info: { title: 'Informations', text: 'Les détails pratiques seront ajoutés prochainement.' },
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
@@ -85,8 +85,8 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Localizzazione', text: 'Castello Marchione, Conversano, Italia'},
           info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
+          rsvp: { title: 'confirma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -95,7 +95,7 @@
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           info: { title: 'Information', text: 'Practical details will be added soon.' },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };
       const SUPPORTED_LANGS = Object.keys(I18N);

--- a/liste-noce.html
+++ b/liste-noce.html
@@ -97,7 +97,7 @@
             item3: 'Contribuire alla nostra futura casa.',
             text2: 'Condivideremo presto il link alla lista completa.'
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'RSVP' }
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' }
         },
         en: {
           registry: {

--- a/localisation.html
+++ b/localisation.html
@@ -253,7 +253,7 @@
             }
           },
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
@@ -311,8 +311,8 @@
               outro: 'Musica, luci e pura energia del sud.'
             }
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
+          rsvp: { title: 'confirma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -371,7 +371,7 @@
             }
           },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };
       const SUPPORTED_LANGS = Object.keys(I18N);

--- a/rsvp.html
+++ b/rsvp.html
@@ -65,7 +65,7 @@
     <main>
       <section id="rsvp">
         <h2 data-i18n="rsvp.title">RSVP</h2>
-        <p data-i18n="rsvp.text">Merci de confirmer votre présence avant le 1er mai 2026.</p>
+        <p data-i18n="rsvp.text">Merci de confirmer votre présence avant le 30 juin 2026.</p>
         <a href="https://tally.so/r/mZxQ7a" class="cta" target="_blank" data-i18n="rsvp.cta">Répondre au formulaire</a>
       </section>
     </main>
@@ -77,15 +77,15 @@
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Localizzazione', text: 'Castello Marchione, Conversano, Italia'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
+          rsvp: { title: 'confirma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -93,7 +93,7 @@
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };
       const SUPPORTED_LANGS = Object.keys(I18N);

--- a/wedding.html
+++ b/wedding.html
@@ -205,7 +205,7 @@
           },
           location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 1er mai 2026.', cta: 'Répondre au formulaire'}
+          rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
@@ -223,8 +223,8 @@
             party_note: 'Pista da ballo aperta fino a tardi.'
           },
           location: { title: 'Localizzazione', text: 'Castello Marchione, Conversano, Italia'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Vi preghiamo di confermare entro il 1° maggio 2026.', cta: 'Rispondere al modulo'}
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
+          rsvp: { title: 'confirma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
@@ -243,7 +243,7 @@
           },
           location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
-          rsvp: { title: 'RSVP', text: 'Please confirm your presence before May 1, 2026.', cta: 'Fill out the form'}
+          rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };
       const SUPPORTED_LANGS = Object.keys(I18N);


### PR DESCRIPTION
### Motivation
- Standardize the RSVP wording for the Italian locale and move the RSVP confirmation deadline from May 1, 2026 to June 30, 2026 across the site.
- Ensure the visible default RSVP paragraph on the `rsvp.html` page and all localized strings reflect the new deadline.

### Description
- Updated localized I18N objects in `index.html`, `info.html`, `localisation.html`, `rsvp.html`, `wedding.html`, and `liste-noce.html` to set the confirmation deadline to June 30, 2026 for French, Italian, and English translations.
- Replaced the Italian `nav.rsvp` and Italian `rsvp.title` labels from `RSVP` to `confirma` in the I18N blocks across the above files.
- Replaced the default RSVP paragraph in `rsvp.html` to read the new French deadline (`30 juin 2026`).
- Changes were committed to the current branch with an appropriate commit message.

### Testing
- Ran a project-wide search (`rg`) to verify there are no remaining occurrences of the old deadlines (`May 1, 2026`, `1er mai 2026`, `1° maggio 2026`) and to confirm presence of `June 30, 2026` and `confirma`, which succeeded.
- Verified the modified files are staged and committed by running `git status --short` and `git commit`, which reported a successful commit including the six changed HTML files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f5052a94832c96cb4debf5af0226)