### PR TITLE
Update Italian 'location' label to 'Come arrivare'

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,9 +158,9 @@
           cta: 'Confermare la presenza',
           countdown: { days: 'Giorni', hours: 'Ore', minutes: 'Minuti', seconds: 'Secondi' },
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
-          location: { title: 'Localizzazione', text: 'Castello Marchione, Conversano, Italia'},
+          location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
           info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
           rsvp: { title: 'confirma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {

--- a/info.html
+++ b/info.html
@@ -83,9 +83,9 @@
           date: '08 agosto 2026 · Castello Marchione',
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
-          location: { title: 'Localizzazione', text: 'Castello Marchione, Conversano, Italia'},
+          location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
           info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
           rsvp: { title: 'confirma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {

--- a/liste-noce.html
+++ b/liste-noce.html
@@ -97,7 +97,7 @@
             item3: 'Contribuire alla nostra futura casa.',
             text2: 'Condivideremo presto il link alla lista completa.'
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' }
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' }
         },
         en: {
           registry: {

--- a/localisation.html
+++ b/localisation.html
@@ -260,7 +260,7 @@
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: {
-            title: 'Localizzazione',
+            title: 'Come arrivare',
             hero: 'Dove diremo «sì»',
             core: { line1: 'Castello Marchione', line2: 'Sud Italia', line3: 'Strada Provinciale 101, km 6.400', line4: '70014 Conversano (Bari) Puglia', line5: '16:30' },
             mapsLabel: '📍 Google Maps:',
@@ -311,7 +311,7 @@
               outro: 'Musica, luci e pura energia del sud.'
             }
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
           rsvp: { title: 'confirma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {

--- a/rsvp.html
+++ b/rsvp.html
@@ -83,8 +83,8 @@
           date: '08 agosto 2026 · Castello Marchione',
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
-          location: { title: 'Localizzazione', text: 'Castello Marchione, Conversano, Italia'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
+          location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
           rsvp: { title: 'confirma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {

--- a/wedding.html
+++ b/wedding.html
@@ -222,8 +222,8 @@
             party: 'Festa & DJ set',
             party_note: 'Pista da ballo aperta fino a tardi.'
           },
-          location: { title: 'Localizzazione', text: 'Castello Marchione, Conversano, Italia'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Localizzazione', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
+          location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'confirma' },
           rsvp: { title: 'confirma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {


### PR DESCRIPTION
### Motivation
- Harmonize the Italian wording for the site location label so navigation and section titles use a clearer phrasing.
- Ensure the Italian translations shown in the UI read "Come arrivare" instead of "Localizzazione" for consistency across pages.

### Description
- Replaced the Italian `location.title` and `nav.location` strings from `Localizzazione` to `Come arrivare` in the shared I18N dictionaries embedded in site pages.
- Changes were applied to six HTML pages: `index.html`, `info.html`, `liste-noce.html`, `localisation.html`, `rsvp.html`, and `wedding.html`.
- No other translation keys or languages were modified.

### Testing
- Ran the automated replacement script that updated the affected HTML files and it completed successfully. 
- Verified the repository-wide search with `rg -n "Localizzazione|Come arrivare" *.html` shows only the updated `Come arrivare` occurrences and no remaining `Localizzazione` matches.
- Confirmed the modified files are present in the working tree and the changes produced the expected diffs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f670c0e0832cb66794877c8fae81)