### PR TITLE
Swap homepage name order to Ilyes & Fidalma

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Fidalma & Ilyes — 08·08·2026 </title>
+    <title>Ilyes & Fidalma — 08·08·2026 </title>
 
     <!-- Favicon inline (branche d'olivier) + fallback fichier -->
     <link rel="icon" type="image/svg+xml"
@@ -103,7 +103,7 @@
         <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
       </nav>
       <div class="hero-content">
-        <h1>Fidalma & Ilyes</h1>
+        <h1>Ilyes & Fidalma</h1>
         <div class="countdown" aria-label="Compte à rebours">
           <div class="countdown-item">
             <div class="flip" data-unit="days">


### PR DESCRIPTION
### Motivation
- Align the homepage presentation with the requested name order by placing `Ilyes` before `Fidalma` in visible page metadata and heading.

### Description
- Updated the document `<title>` in `index.html` from "Fidalma & Ilyes — 08·08·2026" to "Ilyes & Fidalma — 08·08·2026".
- Updated the hero `<h1>` in `index.html` to display "Ilyes & Fidalma".

### Testing
- Ran `git -C /workspace/WEDDING diff -- index.html` which confirmed the two text substitutions (success).
- Ran `git -C /workspace/WEDDING status --short` which reported no uncommitted changes after the update (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51cb9f15c832cb1f73c3cd61647d5)