### PR TITLE
Improve localisation map layout and panel spacing

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -39,7 +39,7 @@
       nav.topnav a:hover,nav.topnav a.active{opacity:.7;}
       nav.topnav .rsvp-btn{border:1px solid var(--text);padding:8px 16px;border-radius:999px;}
       nav.topnav .rsvp-btn:hover{background:var(--text);color:#fff;border-color:var(--text);opacity:1;}
-      main{padding:120px 20px 80px;max-width:1000px;margin:0 auto;}
+      main{padding:120px 20px 80px;max-width:1180px;margin:0 auto;}
       section{text-align:left;background:var(--surface);border:1px solid var(--border);border-radius:32px;padding:40px 32px;box-shadow:0 24px 48px rgba(0,0,0,.06);}
       h2{font-size:36px;color:var(--accent);margin-bottom:20px;font-weight:500;letter-spacing:-0.01em;}
       p{color:var(--muted);}
@@ -50,11 +50,11 @@
       .location-core{line-height:1.8;color:var(--muted);}
       .location-link{display:inline-block;margin-top:8px;color:var(--accent-strong);text-decoration:none;}
       .location-link:hover{text-decoration:underline;}
-      .map-layout{display:grid;grid-template-columns:minmax(300px,380px) minmax(0,1fr);gap:18px;align-items:start;margin:24px 0 10px;}
-      .map{width:100%;aspect-ratio:16/9;border:1px solid var(--border);border-radius:20px;box-shadow:0 16px 30px rgba(0,0,0,.08);overflow:hidden;}
+      .map-layout{display:grid;grid-template-columns:minmax(280px,340px) minmax(0,1.35fr);gap:22px;align-items:stretch;margin:24px 0 10px;}
+      .map{width:100%;height:clamp(420px,62vh,640px);border:1px solid var(--border);border-radius:20px;box-shadow:0 16px 30px rgba(0,0,0,.08);overflow:hidden;}
       .poi-marker{width:14px;height:14px;border-radius:50%;border:2px solid #fff;box-shadow:0 1px 6px rgba(0,0,0,.35);}
       .poi-marker.is-active{width:22px;height:22px;border-width:3px;box-shadow:0 0 0 4px rgba(255,255,255,.95),0 2px 12px rgba(0,0,0,.45);}
-      .map-discover{margin:0;padding:20px;border:1px solid var(--border);border-radius:20px;background:#fff;display:grid;gap:14px;}
+      .map-discover{margin:0;padding:20px;border:1px solid var(--border);border-radius:20px;background:#fff;display:flex;flex-direction:column;gap:14px;min-height:clamp(420px,62vh,640px);}
       .map-discover h3{margin-top:0;font-size:22px;}
       .map-category-buttons{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:14px;}
       .map-category-btn,.map-place-btn{border:1px solid var(--border);background:#fff;color:var(--text);padding:8px 14px;border-radius:999px;cursor:pointer;font:inherit;transition:all .2s ease;}
@@ -76,7 +76,10 @@
       .map-nav-btn{border:1px solid var(--border);background:#fff;color:var(--text);padding:7px 10px;border-radius:999px;cursor:pointer;font:inherit;line-height:1;}
       .map-nav-btn:hover{border-color:var(--accent-strong);color:var(--accent-strong);}
       .map-nav-btn:disabled{opacity:.35;cursor:not-allowed;}
-      .map-place-list{list-style:none;margin:0;padding:0;display:grid;gap:8px;max-height:300px;overflow:auto;}
+      .map-place-list{list-style:none;margin:0;padding:0;display:grid;gap:8px;min-height:200px;flex:1;overflow:auto;}
+      @media (max-width:1024px){
+        .map-layout{grid-template-columns:minmax(270px,320px) minmax(0,1fr);}
+      }
       .map-place-btn{width:100%;border-radius:14px;text-align:left;padding:10px 12px;display:grid;gap:4px;}
       .map-place-btn span{display:flex;align-items:center;gap:8px;}
       .map-place-dot{width:10px;height:10px;border-radius:50%;display:inline-block;flex:0 0 auto;}
@@ -87,6 +90,7 @@
       .hamburger{display:none;}
       @media (max-width:768px){
         .map-layout{grid-template-columns:1fr;}
+        .map,.map-discover{min-height:unset;height:420px;}
         .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
         nav.topnav{display:none; position:absolute; top:70px; right:10px; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}


### PR DESCRIPTION
### Motivation
- Rendre la carte de l'onglet « Localisation » plus lisible et visuellement dominante car l'ancienne mise en page la rendait trop petite par rapport au panneau de légende. 
- Réduire l'espace vide à droite de la zone légende en rééquilibrant la grille pour mieux utiliser l'espace horizontal. 
- Assurer un comportement responsive harmonieux (tablette / mobile) tout en gardant la légende alignée visuellement avec la carte. 

### Description
- Modifié `localisation.html` pour augmenter la largeur utile de la page en passant `main { max-width: 1000px }` → `max-width: 1180px` afin de donner plus d'espace horizontal à la carte. 
- Rééquilibré la grille de la section carte/légende en ajustant `.map-layout` de `minmax(300px,380px) minmax(0,1fr)` → `minmax(280px,340px) minmax(0,1.35fr)` et augmenté l'écart (`gap: 18px` → `22px`). 
- Augmenté la taille de la carte en hauteur via `.map { height: clamp(420px, 62vh, 640px) }` et rendu le panneau légende (`.map-discover`) en `flex` avec `min-height` assorti pour s'aligner visuellement. 
- Rendu la liste des lieux flexible (`.map-place-list { flex: 1; min-height: 200px }`), ajouté un breakpoint intermédiaire `@media (max-width:1024px)` pour ajuster la grille tablette, et forcé une hauteur mobile fixe via media query pour `.map` et `.map-discover`. 

### Testing
- Exécuté `git diff -- localisation.html` pour vérifier les changements applicables et la diff générée, et la sortie était conforme. 
- Vérifié l'état du dépôt avec `git status --short` et confirmé le fichier modifié (`M localisation.html`). 
- Commit effectué avec `git commit -m "Improve localisation map layout and panel spacing"` et la commande s'est terminée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7b89b230c832cb1496842ab9a85d1)