### PR TITLE
Fix mobile navigation and language switch on liste-noce page

### DIFF
--- a/liste-noce.html
+++ b/liste-noce.html
@@ -45,12 +45,14 @@
       .iban-card .iban-label{display:block;color:var(--muted);font-size:13px;letter-spacing:.04em;text-transform:uppercase;margin-bottom:8px;}
       .hamburger{display:none;}
       @media (max-width:768px){
-        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
+        .lang-switch{position:fixed; top:20px; left:16px; z-index:40;}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:16px; z-index:50; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
-        nav.topnav{display:none; position:absolute; top:70px; right:10px; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
+        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:45; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
         nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}
         nav.topnav a{color:var(--text); border-bottom:none;}
         nav.topnav .rsvp-btn{border-color:var(--text);}
+        main{padding-top:110px;}
       }
     </style>
   </head>
@@ -159,7 +161,13 @@
         history.replaceState(null, '', `${url.pathname.split('/').pop()}${url.search}${url.hash}`);
         if (typeof syncIbanButtonLabel === 'function') syncIbanButtonLabel();
       }
-      document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>applyTranslations(btn.dataset.lang)));
+      document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>{
+        applyTranslations(btn.dataset.lang);
+        if (topnav && topnav.classList.contains('open')){
+          topnav.classList.remove('open');
+          burger && burger.setAttribute('aria-expanded','false');
+        }
+      }));
       applyTranslations(getInitialLang());
 
       const ibanToggleButton = document.getElementById('toggle-iban');


### PR DESCRIPTION
### Motivation
- The mobile `liste-noce.html` header controls were covered by page content or the open burger menu, making the language buttons and menu links unreliable to tap.
- The change aims to ensure header controls remain above content and that language switching does not leave the burger menu open and overlapping content.

### Description
- Updated mobile CSS in `liste-noce.html` to use `position: fixed` for `.lang-switch`, `.hamburger`, and `nav.topnav` and added explicit `z-index` values to enforce stacking order.
- Added extra top spacing on mobile by modifying `main{padding-top:110px;}` to avoid content colliding with fixed controls.
- Adjusted the mobile `nav.topnav` positioning to `position: fixed` and kept the open/closed animation behavior via the `.open` class.
- Modified the language switch handler so clicking a language button calls `applyTranslations(...)` and closes the burger menu if it is open by removing the `.open` class and resetting `aria-expanded` on the burger button.

### Testing
- Applied the automated patch to `liste-noce.html` and verified the file was updated successfully (script run completed without error).
- Reviewed the resulting diff and statically inspected the edited CSS and JS blocks for syntax issues and found none.
- Performed a static check of the header event handlers to confirm the burger toggle and language-switch-to-close behavior are present and consistent; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c9aa66ac832cbd0e848ba6319a9f)