### PR TITLE
Fix non-clickable buttons on liste-noce page in all languages

### DIFF
--- a/liste-noce.html
+++ b/liste-noce.html
@@ -91,8 +91,8 @@
         fr: {
           registry: {
             title: 'Liste de noce',
-            text: 'Nous voulons remercier nos familles et nos amis pour l'amour et le soutien qu'ils nous ont témoignés au début de notre avenir ensemble. Vous avoir à nos côtés pour le plus beau jour de notre vie est déjà le plus grand des cadeaux. Mais si vous souhaitez nous aider à réaliser notre lune de miel de rêve, nous vous en serons profondément reconnaissants.',
-            text2: 'Les objets se perdent, se cassent, s'oublient. Un voyage est une émotion qui reste gravée pour toujours dans la mémoire. Merci à vous qui, par votre contribution, nous aiderez à réaliser le voyage de noces de nos rêves.',
+            text: "Nous voulons remercier nos familles et nos amis pour l'amour et le soutien qu'ils nous ont témoignés au début de notre avenir ensemble. Vous avoir à nos côtés pour le plus beau jour de notre vie est déjà le plus grand des cadeaux. Mais si vous souhaitez nous aider à réaliser notre lune de miel de rêve, nous vous en serons profondément reconnaissants.",
+            text2: "Les objets se perdent, se cassent, s'oublient. Un voyage est une émotion qui reste gravée pour toujours dans la mémoire. Merci à vous qui, par votre contribution, nous aiderez à réaliser le voyage de noces de nos rêves.",
             showIban: "Afficher l'IBAN",
             hideIban: "Masquer l'IBAN",
             transferTitle: 'Coordonnées bancaires'
@@ -102,8 +102,8 @@
         it: {
           registry: {
             title: 'Lista nozze',
-            text: 'Vogliamo ringraziare le nostre famiglie e i nostri amici per l'amore e il sostegno che ci hanno dimostrato all'inizio del nostro futuro insieme. Averti con noi nel nostro giorno più bello è il regalo più grande che possiate farci, ma se volete aiutarci a realizzare la nostra luna di miele da sogno ve ne saremo profondamente grati.',
-            text2: 'Gli oggetti si perdono, si rompono, si dimenticano. Un viaggio è un'emozione che resta per sempre impressa nella memoria. Grazie a voi che contribuendo, ci aiuterete a realizzare il viaggio di nozze dei nostri sogni.',
+            text: "Vogliamo ringraziare le nostre famiglie e i nostri amici per l'amore e il sostegno che ci hanno dimostrato all'inizio del nostro futuro insieme. Averti con noi nel nostro giorno più bello è il regalo più grande che possiate farci, ma se volete aiutarci a realizzare la nostra luna di miele da sogno ve ne saremo profondamente grati.",
+            text2: "Gli oggetti si perdono, si rompono, si dimenticano. Un viaggio è un'emozione che resta per sempre impressa nella memoria. Grazie a voi che contribuendo, ci aiuterete a realizzare il viaggio di nozze dei nostri sogni.",
             showIban: 'Mostra IBAN',
             hideIban: 'Nascondi IBAN',
             transferTitle: 'Coordinate bancarie'


### PR DESCRIPTION
### Motivation
- The wedding registry page script stopped running because translation strings in the inline i18n object contained unescaped apostrophes, causing a JS parse error and preventing button interactions.

### Description
- Replaced affected single-quoted translation literals with double-quoted strings in `liste-noce.html` for French and Italian entries so embedded apostrophes no longer break the script.
- The change is limited to the inline `<script>` i18n object and restores normal behavior for the language switch, mobile menu, and IBAN toggle without altering UI text content.

### Testing
- Performed a JS parse/compile check by extracting the inline script and executing it with Node using `new Function(...)`, which now prints `JS_OK` indicating the script compiles successfully.
- No other automated tests were applicable; the Node check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ce4c328c832caa15916887676af2)