### PR TITLE
Fix mobile navigation controls on liste-noce page

### DIFF
--- a/liste-noce.html
+++ b/liste-noce.html
@@ -161,12 +161,18 @@
         history.replaceState(null, '', `${url.pathname.split('/').pop()}${url.search}${url.hash}`);
         if (typeof syncIbanButtonLabel === 'function') syncIbanButtonLabel();
       }
+      const burger = document.querySelector('.hamburger');
+      const topnav = document.getElementById('topnav');
+
+      function closeMobileNav(){
+        if (!topnav) return;
+        topnav.classList.remove('open');
+        if (burger) burger.setAttribute('aria-expanded','false');
+      }
+
       document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>{
         applyTranslations(btn.dataset.lang);
-        if (topnav && topnav.classList.contains('open')){
-          topnav.classList.remove('open');
-          burger && burger.setAttribute('aria-expanded','false');
-        }
+        closeMobileNav();
       }));
       applyTranslations(getInitialLang());
 
@@ -205,17 +211,12 @@
       }
       highlightActiveLink();
 
-      const burger = document.querySelector('.hamburger');
-      const topnav = document.getElementById('topnav');
       if (burger && topnav){
         burger.addEventListener('click', ()=>{
           const open = topnav.classList.toggle('open');
           burger.setAttribute('aria-expanded', String(open));
         });
-        topnav.querySelectorAll('a').forEach(a=>a.addEventListener('click',()=>{
-          topnav.classList.remove('open');
-          burger.setAttribute('aria-expanded','false');
-        }));
+        topnav.querySelectorAll('a').forEach(a=>a.addEventListener('click', closeMobileNav));
       }
     </script>
   </body>


### PR DESCRIPTION
### Motivation
- On mobile the burger menu and language switch on the `liste-noce.html` page could leave the menu stuck open or not respond to interactions, making it impossible to access navigation options from that category like on other pages.

### Description
- Initialize `burger` and `topnav` earlier in the page script and extract a `closeMobileNav()` helper that removes the `open` class and synchronizes the `aria-expanded` state.
- Use `closeMobileNav()` from the language switch handler and attach it to mobile nav link clicks so the menu reliably closes after selecting a language or a link.
- Keep the original toggle logic for opening the menu intact while centralizing close behavior to match the other pages.

### Testing
- Ran `git diff --check` which reported no issues and completed successfully.
- Verified repository status with `git status --short` showing the single modified file `liste-noce.html` and committed the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e918ef1fdc832cb273678806d93e53)