### PR TITLE
Fix mobile hamburger menu interaction and layering

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,9 +71,9 @@
       /* === Mobile hamburger menu === */
       .hamburger{display:none;}
       @media (max-width:768px){
-        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:999px; border:1px solid rgba(255,255,255,.6); background:rgba(255,255,255,.12); color:#fff; cursor:pointer;}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:1000; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid rgba(255,255,255,.6); background:rgba(255,255,255,.12); color:#fff; cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid #fff; outline-offset:2px;}
-        nav.topnav{display:none; position:absolute; top:70px; right:10px; flex-direction:column; gap:12px; background:rgba(255,255,255,.95); padding:14px; border-radius:16px; border:1px solid rgba(255,255,255,.6); box-shadow:0 12px 30px rgba(0,0,0,.18); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
+        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:999; flex-direction:column; gap:12px; background:rgba(255,255,255,.95); padding:14px; border-radius:16px; border:1px solid rgba(255,255,255,.6); box-shadow:0 12px 30px rgba(0,0,0,.18); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
         nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}
         nav.topnav a{color:var(--text); border-bottom:none;}
         nav.topnav .rsvp-btn{border-color:var(--text);}
@@ -91,7 +91,7 @@
         <button data-lang="it">IT</button>
         <button data-lang="en">EN</button>
       </div>
-      <button class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
+      <button type="button" class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
         <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
       </button>
       <nav class="topnav" id="topnav">

--- a/info.html
+++ b/info.html
@@ -43,9 +43,9 @@
         section{padding:28px 20px;}
         h2{font-size:30px;}
         .intro{font-size:16px;}
-        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:1000; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
-        nav.topnav{display:none; position:absolute; top:70px; right:10px; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
+        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:999; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
         nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}
         nav.topnav a{color:var(--text); border-bottom:none;}
         nav.topnav .rsvp-btn{border-color:var(--text);}
@@ -58,7 +58,7 @@
       <button data-lang="it">IT</button>
       <button data-lang="en">EN</button>
     </div>
-    <button class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
+    <button type="button" class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
     </button>
     <nav class="topnav" id="topnav">

--- a/liste-noce.html
+++ b/liste-noce.html
@@ -46,9 +46,9 @@
       .hamburger{display:none;}
       @media (max-width:768px){
         .lang-switch{position:fixed; top:20px; left:16px; z-index:40;}
-        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:16px; z-index:50; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:16px; z-index:1000; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
-        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:45; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
+        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:999; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
         nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}
         nav.topnav a{color:var(--text); border-bottom:none;}
         nav.topnav .rsvp-btn{border-color:var(--text);}
@@ -62,7 +62,7 @@
       <button data-lang="it">IT</button>
       <button data-lang="en">EN</button>
     </div>
-    <button class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
+    <button type="button" class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
     </button>
     <nav class="topnav" id="topnav">

--- a/localisation.html
+++ b/localisation.html
@@ -96,9 +96,9 @@
         .map-discover h3{margin-top:18px;}
         .map-discover.is-open{transform:translateY(0);}
         .map-discover .map-place-list{max-height:none;}
-        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:1000; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
-        nav.topnav{display:none; position:absolute; top:70px; right:10px; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
+        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:999; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
         nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}
         nav.topnav a{color:var(--text); border-bottom:none;}
         nav.topnav .rsvp-btn{border-color:var(--text);}
@@ -111,7 +111,7 @@
       <button data-lang="it">IT</button>
       <button data-lang="en">EN</button>
     </div>
-    <button class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
+    <button type="button" class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
     </button>
     <nav class="topnav" id="topnav">

--- a/rsvp.html
+++ b/rsvp.html
@@ -36,9 +36,9 @@
       .cta:hover{background:transparent;color:var(--text);}
       .hamburger{display:none;}
       @media (max-width:768px){
-        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:1000; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
-        nav.topnav{display:none; position:absolute; top:70px; right:10px; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
+        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:999; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
         nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}
         nav.topnav a{color:var(--text); border-bottom:none;}
         nav.topnav .rsvp-btn{border-color:var(--text);}
@@ -51,7 +51,7 @@
       <button data-lang="it">IT</button>
       <button data-lang="en">EN</button>
     </div>
-    <button class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
+    <button type="button" class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
     </button>
     <nav class="topnav" id="topnav">

--- a/wedding.html
+++ b/wedding.html
@@ -110,9 +110,9 @@
       }
       .hamburger{display:none;}
       @media (max-width:768px){
-        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:absolute; top:20px; right:20px; z-index:4; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:1000; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
-        nav.topnav{display:none; position:absolute; top:70px; right:10px; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
+        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:999; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
         nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}
         nav.topnav a{color:var(--text); border-bottom:none;}
         nav.topnav .rsvp-btn{border-color:var(--text);}
@@ -125,7 +125,7 @@
       <button data-lang="it">IT</button>
       <button data-lang="en">EN</button>
     </div>
-    <button class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
+    <button type="button" class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
     </button>
     <nav class="topnav" id="topnav">


### PR DESCRIPTION
### Motivation
- The mobile hamburger was not reliably opening the nav because it could be untappable or behind other elements and the button lacked an explicit `type`, causing unexpected behavior on touch devices.

### Description
- Make the mobile hamburger `position: fixed`, add `z-index: 1000` and `touch-action: manipulation`, and make the dropdown `nav.topnav` `position: fixed` with `z-index: 999` so the button and menu sit above page content and respond to taps.
- Add `type="button"` to the hamburger `<button>` element on all pages to prevent implicit form/submit behavior and improve click reliability.
- Applied these changes to `index.html`, `wedding.html`, `localisation.html`, `info.html`, `liste-noce.html`, and `rsvp.html`.

### Testing
- Ran `git diff --check` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8e3dc178832cbcc1eb1fa8118ab8)