### PR TITLE
Fix mobile burger menu visibility on localisation page

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -96,10 +96,10 @@
         .map-discover h3{margin-top:18px;}
         .map-discover.is-open{transform:translateY(0);}
         .map-discover .map-place-list{max-height:none;}
-        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:1000; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:3001; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
-        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:999; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
-        nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}
+        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:3000; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; visibility:hidden; pointer-events:none; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease, visibility .3s ease;}
+        nav.topnav.open{display:flex; opacity:1; visibility:visible; pointer-events:auto; transform:translateY(0);}
         nav.topnav a{color:var(--text); border-bottom:none;}
         nav.topnav .rsvp-btn{border-color:var(--text);}
       }
@@ -716,10 +716,6 @@
         setMapSheetState(isMapSheetOpen);
       }
       document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>applyTranslations(btn.dataset.lang)));
-      initInteractiveMap();
-      applyTranslations(getInitialLang());
-      setupMapCategories();
-      setupMapMobileSheet();
 
       function highlightActiveLink(){
         const current = location.pathname.split('/').pop() || 'index.html';
@@ -742,6 +738,11 @@
           burger.setAttribute('aria-expanded','false');
         }));
       }
+
+      initInteractiveMap();
+      applyTranslations(getInitialLang());
+      setupMapCategories();
+      setupMapMobileSheet();
     </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- The mobile hamburger on `localisation.html` was responding to clicks but could stay hidden behind the interactive map UI, so the menu must reliably appear and accept input on mobile.

### Description
- Increase the stacking order for the mobile trigger and panel by raising `.hamburger` `z-index` to `3001` and `nav.topnav` to `3000`, and add `visibility`/`pointer-events` handling for the closed/open states to avoid the "click reacts but menu does not appear" issue.
- Reorder script initialization so the burger event wiring runs before calling `initInteractiveMap`, `applyTranslations`, `setupMapCategories`, and `setupMapMobileSheet`, preventing later initialization from interfering with menu interactivity.
- All changes are confined to the `localisation.html` file.

### Testing
- Ran `git diff --check` which returned no issues (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb904b59b0832cb03ec8abf742aeaf)