### PR TITLE
Fix mobile hamburger/menu layering on liste-noce.html

### DIFF
--- a/liste-noce.html
+++ b/liste-noce.html
@@ -46,10 +46,10 @@
       .hamburger{display:none;}
       @media (max-width:768px){
         .lang-switch{position:fixed; top:20px; left:16px; z-index:40;}
-        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:16px; z-index:1000; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:3001; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
-        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:999; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
-        nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}
+        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:3000; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; visibility:hidden; pointer-events:none; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease, visibility .3s ease;}
+        nav.topnav.open{display:flex; opacity:1; visibility:visible; pointer-events:auto; transform:translateY(0);}
         nav.topnav a{color:var(--text); border-bottom:none;}
         nav.topnav .rsvp-btn{border-color:var(--text);}
         main{padding-top:110px;}


### PR DESCRIPTION
### Motivation
- Mobile users reported the top-right hamburger toggle not working on the "Liste de noce" page because it was visually or interactively obscured by page content, so the mobile menu needs to match the behavior used on other pages.

### Description
- Adjusted the mobile hamburger button in `liste-noce.html` by changing `right` to `20px` and increasing its `z-index` to `3001` so the toggle stays on top of content.
- Updated `nav.topnav` mobile styles in `liste-noce.html` to `z-index:3000` and added `visibility` and `pointer-events` guards plus a `visibility` transition to make closed/open states non-interactive when closed and interactive when open.

### Testing
- Ran `git diff -- liste-noce.html` to verify the CSS changes were scoped to the registry page and the diff looks correct (succeeded).
- Ran `git status --short` to confirm the file is staged/modified and created a commit for the change (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9225b3fc832c876d8745b3ac61f1)