### PR TITLE
Add mobile hamburger menu to liste-noce.html

### DIFF
--- a/liste-noce.html
+++ b/liste-noce.html
@@ -43,9 +43,13 @@
       .iban-card[hidden]{display:none;}
       .iban-card p{margin:0;color:var(--text);line-height:1.6;font-size:16px;}
       .iban-card .iban-label{display:block;color:var(--muted);font-size:13px;letter-spacing:.04em;text-transform:uppercase;margin-bottom:8px;}
+      .hamburger{display:none;}
       @media (max-width:768px){
         .lang-switch{position:fixed; top:20px; left:16px; z-index:40;}
-        nav.topnav{position:fixed; top:20px; right:16px; z-index:3000; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12);}
+        .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:3001; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
+        .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
+        nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:3000; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease;}
+        nav.topnav.open{display:flex; opacity:1; transform:translateY(0);}
         nav.topnav a{color:var(--text); border-bottom:none;}
         nav.topnav .rsvp-btn{border-color:var(--text);}
         main{padding-top:110px;}
@@ -58,6 +62,9 @@
       <button data-lang="it">IT</button>
       <button data-lang="en">EN</button>
     </div>
+    <button type="button" class="hamburger" aria-label="Ouvrir le menu" aria-controls="topnav" aria-expanded="false">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+    </button>
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
@@ -193,6 +200,19 @@
         });
       }
       highlightActiveLink();
+
+      const burger = document.querySelector('.hamburger');
+      const topnav = document.getElementById('topnav');
+      if (burger && topnav){
+        burger.addEventListener('click', ()=>{
+          const open = topnav.classList.toggle('open');
+          burger.setAttribute('aria-expanded', String(open));
+        });
+        topnav.querySelectorAll('a').forEach(a=>a.addEventListener('click',()=>{
+          topnav.classList.remove('open');
+          burger.setAttribute('aria-expanded','false');
+        }));
+      }
 
     </script>
   </body>


### PR DESCRIPTION
### Motivation
- Harmoniser la navigation mobile de la page de la liste de noce avec les autres pages du site en ajoutant un bouton burger qui donne accès aux autres catégories sur petit écran.

### Description
- Mise à jour du fichier `liste-noce.html` pour ajouter un bouton `button.hamburger` (SVG) placé à côté de la bascule de langue. 
- Ajout de règles CSS pour `.hamburger` et modification du comportement mobile de `nav.topnav` afin qu'il soit masqué par défaut et s'affiche avec la classe `.open` comme sur les autres pages. 
- Ajout de JavaScript pour gérer le toggle du menu (mise à jour de `aria-expanded`, bascule de la classe `.open`) et pour fermer automatiquement le menu après un clic sur un lien.

### Testing
- Aucun test automatisé n'est configuré pour ce site statique, donc aucun test CI/automatisé n'a été exécuté.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9d2678f8832c858deac1a852d1d2)