### PR TITLE
Fixe les contrôles de langue et de navigation sur la page Liste de noce

### DIFF
--- a/liste-noce.html
+++ b/liste-noce.html
@@ -20,10 +20,10 @@
       }
       *{box-sizing:border-box;}
       body{margin:0;font-family:'Inter','Helvetica Neue',Arial,sans-serif;color:var(--text);background:var(--background);-webkit-font-smoothing:antialiased;}
-      .lang-switch{position:absolute;top:20px;left:20px;z-index:3;}
+      .lang-switch{position:fixed;top:20px;left:20px;z-index:40;}
       .lang-switch button{margin-right:6px;border:1px solid var(--border);background:transparent;color:var(--text);padding:6px 12px;border-radius:999px;cursor:pointer;font-weight:500;transition:all .3s ease;}
       .lang-switch button.active{background:var(--text);color:#fff;border-color:var(--text);}
-      nav.topnav{position:absolute;top:20px;right:20px;display:flex;gap:20px;z-index:3;}
+      nav.topnav{position:fixed;top:20px;right:20px;display:flex;gap:20px;z-index:40;}
       nav.topnav a{color:var(--text);text-decoration:none;font-weight:500;transition:opacity .3s ease;}
       nav.topnav a:hover,nav.topnav a.active{opacity:.7;}
       nav.topnav .rsvp-btn{border:1px solid var(--text);padding:8px 16px;border-radius:999px;}


### PR DESCRIPTION
### Motivation
- Corriger le comportement où les boutons de langue et le bouton burger déroulant défilent avec le contenu sur `liste-noce.html` pour les rendre fixes en haut comme dans les autres pages.

### Description
- Dans `liste-noce.html` j'ai remplacé `position:absolute` par `position:fixed` et augmenté le `z-index` pour `.lang-switch` afin que le sélecteur de langue reste épinglé en haut lors du scroll.
- Dans `liste-noce.html` j'ai remplacé `position:absolute` par `position:fixed` et augmenté le `z-index` pour `nav.topnav` afin que la navigation reste en haut sur desktop.

### Testing
- Exécutés et réussis : `git diff -- liste-noce.html`, `nl -ba liste-noce.html | sed -n '16,50p'` et `git commit -m "Fixe les contrôles de navigation sur la page liste de noce"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba04945ec832ca7643a033dd5600f)