### PR TITLE
Make localisation map legend static on mobile (remove bottom sheet)

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -84,17 +84,11 @@
       .map-place-list option{padding:8px 10px;border-radius:8px;}
       .map-open-link{display:inline-flex;align-items:center;justify-content:center;padding:10px 14px;border-radius:999px;border:1px solid var(--text);color:var(--text);text-decoration:none;font-weight:500;}
       .map-open-link:hover{background:var(--text);color:#fff;}
-      .map-mobile-toggle{display:none;}
       .hamburger{display:none;}
       @media (max-width:768px){
         .map-layout{grid-template-columns:1fr;}
-        .map{min-height:unset;height:420px;}
-        .map-mobile-toggle{display:inline-flex;align-items:center;justify-content:center;gap:8px;margin:16px 0 8px;border:1px solid var(--text);background:var(--text);color:#fff;border-radius:999px;padding:10px 16px;font:inherit;font-weight:500;cursor:pointer;}
-        .map-mobile-toggle:hover{opacity:.92;}
-        .map-discover{position:fixed;left:0;right:0;bottom:0;z-index:9;margin:0;border-radius:24px 24px 0 0;min-height:unset;height:min(80vh,620px);transform:translateY(calc(100% - 56px));transition:transform .3s ease;box-shadow:0 -18px 36px rgba(0,0,0,.2);}
-        .map-discover::before{content:'';width:44px;height:5px;border-radius:999px;background:#d2d2d7;position:absolute;top:10px;left:50%;transform:translateX(-50%);}
-        .map-discover h3{margin-top:18px;}
-        .map-discover.is-open{transform:translateY(0);}
+        .map{min-height:unset;height:380px;}
+        .map-discover{min-height:unset;height:auto;box-shadow:0 10px 24px rgba(0,0,0,.08);}
         .map-discover .map-place-list{max-height:none;}
         .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:3001; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
@@ -137,10 +131,9 @@
         <p data-i18n="location.description3">Le nom « Marchione » provient de la construction d'origine — probablement datant du XVIe siècle — bâtie pour accueillir la famille Acquaviva d'Aragona lors de parties de chasse. Le toponyme « Marchione » vient de l'altération linguistique de « Macchione », en référence à la vaste forêt qui s'étendait autrefois sur 1 320 hectares. Quelques chênes majestueux, âgés jusqu'à 500 ans, subsistent encore aujourd'hui.</p>
         <p><span data-i18n="location.historyLabel">Pour plus de détails historiques :</span><br /><a class="location-link" href="https://www.castellomarchione.it/tra-storia-e-leggenda/" target="_blank" rel="noopener noreferrer">https://www.castellomarchione.it/tra-storia-e-leggenda/</a></p>
         <div class="map-layout">
-          <button type="button" id="map-mobile-toggle" class="map-mobile-toggle" data-i18n="location.mapDiscover.openSheet">🍽️ Voir la liste des lieux</button>
           <div class="map-discover">
-            <h3 data-i18n="location.mapDiscover.title">🗺️ Explorer la région sur la carte</h3>
-            <p data-i18n="location.mapDiscover.description">Choisissez un lieu à afficher sur la carte.</p>
+            <h3 data-i18n="location.mapDiscover.title">🗺️ Légende & lieux</h3>
+            <p data-i18n="location.mapDiscover.description">Choisissez une catégorie puis un lieu à afficher sur la carte.</p>
             <div class="map-category-buttons">
               <button type="button" class="map-category-btn active" data-category="wedding" data-i18n="location.mapDiscover.categories.wedding">Lieu de mariage</button>
               <button type="button" class="map-category-btn" data-category="visit" data-i18n="location.mapDiscover.categories.visit">Lieux à visiter</button>
@@ -241,16 +234,14 @@
             description3: 'Le nom « Marchione » provient de la construction d\'origine — probablement datant du XVIe siècle — bâtie pour accueillir la famille Acquaviva d\'Aragona lors de parties de chasse. Le toponyme « Marchione » vient de l\'altération linguistique de « Macchione », en référence à la vaste forêt qui s\'étendait autrefois sur 1 320 hectares. Quelques chênes majestueux, âgés jusqu\'à 500 ans, subsistent encore aujourd\'hui.',
             historyLabel: 'Pour plus de détails historiques :',
             mapDiscover: {
-              title: '🗺️ Explorer la région sur la carte',
-              description: 'Choisissez un lieu à afficher sur la carte.',
+              title: '🗺️ Légende & lieux',
+              description: 'Choisissez une catégorie puis un lieu à afficher sur la carte.',
               searchLabel: 'Rechercher un lieu',
               searchPlaceholder: 'Ex : Polignano, Monopoli...',
               openInMaps: 'Ouvrir dans Google Maps',
               prevTitle: 'Lieu précédent',
               nextTitle: 'Lieu suivant',
               resultsCount: '{{count}} résultat(s)',
-              openSheet: '🍽️ Voir la liste des lieux',
-              closeSheet: 'Fermer la liste',
               categories: {
                 wedding: 'Lieu de mariage',
                 visit: 'Lieux à visiter',
@@ -302,16 +293,14 @@
             description3: 'Il nome «Marchione» deriva dalla costruzione originaria — probabilmente risalente al XVI secolo — realizzata per ospitare la famiglia Acquaviva d\'Aragona durante le battute di caccia. Il toponimo «Marchione» nasce dall\'alterazione linguistica di «Macchione», riferita al vasto bosco che un tempo si estendeva su 1.320 ettari. Alcune maestose querce, fino a 500 anni di età, sopravvivono ancora oggi.',
             historyLabel: 'Per maggiori dettagli storici:',
             mapDiscover: {
-              title: '🗺️ Esplora la regione sulla mappa',
-              description: 'Scegli un luogo da visualizzare sulla mappa.',
+              title: '🗺️ Legenda e luoghi',
+              description: 'Scegli una categoria e poi un luogo da visualizzare sulla mappa.',
               searchLabel: 'Cerca un luogo',
               searchPlaceholder: 'Es: Polignano, Monopoli...',
               openInMaps: 'Apri in Google Maps',
               prevTitle: 'Luogo precedente',
               nextTitle: 'Luogo successivo',
               resultsCount: '{{count}} risultato/i',
-              openSheet: '🍽️ Apri l’elenco dei luoghi',
-              closeSheet: 'Chiudi elenco',
               categories: {
                 wedding: 'Luogo del matrimonio',
                 visit: 'Luoghi da visitare',
@@ -363,16 +352,14 @@
             description3: 'The name “Marchione” derives from the original construction — likely dating back to the 16th century — built to host the Acquaviva d\'Aragona family during hunting trips. The toponym “Marchione” comes from the linguistic alteration of “Macchione”, referring to the vast woodland that once extended over 1,320 hectares. Some majestic oak trees, up to 500 years old, still survive today.',
             historyLabel: 'For more historical details:',
             mapDiscover: {
-              title: '🗺️ Explore the region on the map',
-              description: 'Pick a place to display on the map.',
+              title: '🗺️ Legend & places',
+              description: 'Choose a category, then select a place to display on the map.',
               searchLabel: 'Search a place',
               searchPlaceholder: 'E.g. Polignano, Monopoli...',
               openInMaps: 'Open in Google Maps',
               prevTitle: 'Previous place',
               nextTitle: 'Next place',
               resultsCount: '{{count}} result(s)',
-              openSheet: '🍽️ Open places list',
-              closeSheet: 'Close list',
               categories: {
                 wedding: 'Wedding venue',
                 visit: 'Places to visit',
@@ -477,7 +464,6 @@
       let currentMapLang = 'fr';
       let leafletMap = null;
       let fullMapBounds = null;
-      let isMapSheetOpen = false;
       const markerByPlace = new Map();
 
       function getAllMapPlaces(){
@@ -549,7 +535,6 @@
         if (list) list.value = place;
         refreshMarkerHighlight();
         updateMapNavButtons();
-        if (window.matchMedia('(max-width: 768px)').matches) setMapSheetState(false);
       }
 
       function getMapResultsLabel(lang, count){
@@ -645,26 +630,6 @@
         renderMapPlaces(document.documentElement.lang || 'fr');
       }
 
-      function setMapSheetState(nextState){
-        const sheet = document.querySelector('.map-discover');
-        const toggle = document.getElementById('map-mobile-toggle');
-        if (!sheet || !toggle) return;
-        isMapSheetOpen = Boolean(nextState);
-        sheet.classList.toggle('is-open', isMapSheetOpen);
-        const i18n = I18N[currentMapLang]?.location?.mapDiscover || {};
-        const openLabel = i18n.openSheet || 'Open places list';
-        const closeLabel = i18n.closeSheet || 'Close list';
-        toggle.textContent = isMapSheetOpen ? closeLabel : openLabel;
-        toggle.setAttribute('aria-expanded', String(isMapSheetOpen));
-      }
-
-      function setupMapMobileSheet(){
-        const toggle = document.getElementById('map-mobile-toggle');
-        if (!toggle) return;
-        toggle.addEventListener('click', ()=>setMapSheetState(!isMapSheetOpen));
-        setMapSheetState(false);
-      }
-
       function updateLanguageInLinks(lang){
         document.querySelectorAll('a[href]').forEach(link=>{
           const rawHref = link.getAttribute('href');
@@ -713,7 +678,6 @@
         url.searchParams.set('lang', lang);
         history.replaceState(null, '', `${url.pathname.split('/').pop()}${url.search}${url.hash}`);
         renderMapPlaces(lang);
-        setMapSheetState(isMapSheetOpen);
       }
       document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>applyTranslations(btn.dataset.lang)));
 
@@ -742,7 +706,6 @@
       initInteractiveMap();
       applyTranslations(getInitialLang());
       setupMapCategories();
-      setupMapMobileSheet();
     </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the mobile floating bottom-sheet for the localisation map legend/list with a static, in-flow legend so the legend is always visible on mobile and not a movable window.

### Description
- Updated `localisation.html` CSS to remove the mobile bottom-sheet styles, reduce map height on small screens and make the legend (`.map-discover`) a static panel with adjusted box-shadow.
- Removed the mobile toggle button markup and updated the map-discover section header and description to read "Légende & lieux" (FR), "Legenda e luoghi" (IT) and "Legend & places" (EN).
- Cleaned up JavaScript by removing the mobile sheet state and handlers (`isMapSheetOpen`, `setMapSheetState`, `setupMapMobileSheet`) and removed auto-close behavior when selecting a place while preserving category/filter/navigation logic.
- Updated I18N `mapDiscover` copy for FR/IT/EN to match the new static legend UX and removed `openSheet`/`closeSheet` strings.

### Testing
- Ran `git diff --check` to verify there are no whitespace/diff issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba65ed68c832c958c8289ecf9e40c)