### PR TITLE
Fix desktop legend list overflow in localisation map panel

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -79,7 +79,8 @@
       .map-place-list{
         width:100%;
         min-height:220px;
-        flex:1;
+        max-height:clamp(260px,36vh,360px);
+        flex:0 1 auto;
         border:1px solid var(--border);
         border-radius:14px;
         padding:8px;


### PR DESCRIPTION
### Motivation
- On desktop the map legend showed every place and stretched the page; the intent is to display ~4–5 items and keep the rest inside a scrollable list so the page height does not grow indefinitely.

### Description
- Tighten the legend place list styling by updating `.map-place-list` to add a `max-height: clamp(260px,36vh,360px)` and change its flex behaviour to `flex: 0 1 auto` so the list remains compact and scrolls internally.

### Testing
- Verified the edited HTML parses with a small script (`python` + `HTMLParser`) which reported success, and attempted `xmllint --html --noout localisation.html` which failed because `xmllint` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebacabe5b4832cb6429eb45f5a1292)