### PR TITLE
Update August festivals section with detailed events and links

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -263,10 +263,39 @@
         </ul>
         <p data-i18n="location.food.festivalsLabel">Fêtes d'août à ne pas manquer :</p>
         <ul>
-          <li>Festa patronale Madonna della Madia – Monopoli</li>
-          <li>Festa di Sant’Oronzo – Ostuni</li>
-          <li>Sagra del Polpo – Mola di Bari</li>
-          <li>La Notte della Taranta – Salento</li>
+          <li>
+            <strong>Festa patronale Madonna della Madia – Monopoli</strong><br>
+            📅 13 – 16 août 2026<br>
+            Célébration emblématique de la ville de Monopoli, marquée par des processions, des illuminations et la reconstitution spectaculaire de l’arrivée de l’icône de la Vierge par la mer.<br>
+            🔗 <a href="https://it.wikipedia.org/wiki/Madonna_della_Madia" target="_blank" rel="noopener noreferrer">https://it.wikipedia.org/wiki/Madonna_della_Madia</a>
+          </li>
+          <li>
+            <strong>Festa di Sant’Oronzo – Ostuni</strong><br>
+            📅 25 – 27 août 2026<br>
+            Fête patronale de la “Città Bianca”, connue pour sa célèbre cavalcade de chevaux décorés, ses illuminations et ses feux d’artifice.<br>
+            🔗 <a href="https://it.wikipedia.org/wiki/Sant%27Oronzo" target="_blank" rel="noopener noreferrer">https://it.wikipedia.org/wiki/Sant%27Oronzo</a>
+          </li>
+          <li>
+            <strong>Sagra del Polpo – Mola di Bari</strong><br>
+            📅 24 – 26 juillet 2026<br>
+            Festival populaire dédié au poulpe, avec stands de street food, spécialités locales et ambiance festive en bord de mer.<br>
+            🔗 <a href="https://www.facebook.com/lafestadelmaremola" target="_blank" rel="noopener noreferrer">https://www.facebook.com/lafestadelmaremola</a>
+          </li>
+          <li>
+            <strong>La Notte della Taranta – Salento (final à Melpignano)</strong><br>
+            📅 22 août 2026<br>
+            Concert final du plus grand festival de musique traditionnelle du sud de l’Italie, dédié à la pizzica, précédé de plusieurs soirées dans différents villages du Salento.<br>
+            🔗 <a href="https://www.lanottedellataranta.it" target="_blank" rel="noopener noreferrer">https://www.lanottedellataranta.it</a>
+          </li>
+          <li>
+            <strong>Terraròss – concerts de musique populaire pugliese</strong><br>
+            📅 Dates été 2026 à venir<br>
+            Groupe emblématique des Pouilles, les Terraròss font vivre la tradition populaire du Sud de l’Italie à travers pizzica, tarantella, tamburelli, chants et danses.<br>
+            Leur calendrier est généralement publié progressivement avant l’été : nous vous conseillons de vérifier leurs prochaines dates sur leurs pages officielles.<br>
+            🔗 <a href="https://www.terraross.it/?page_id=72" target="_blank" rel="noopener noreferrer">https://www.terraross.it/?page_id=72</a><br>
+            🔗 <a href="https://www.facebook.com/TerrarossOfficial" target="_blank" rel="noopener noreferrer">https://www.facebook.com/TerrarossOfficial</a><br>
+            🔗 <a href="https://www.instagram.com/terrarossofficial/" target="_blank" rel="noopener noreferrer">https://www.instagram.com/terrarossofficial/</a>
+          </li>
         </ul>
         <p data-i18n="location.food.outro">Musique, lumières et pure énergie du sud.</p>
       </section>


### PR DESCRIPTION
### Motivation
- Replace the terse “Fêtes d'août à ne pas manquer” list in the localisation page with a richer, user-facing description that includes 2026 dates, short descriptions and authoritative links for seasonal events.

### Description
- Updated `localisation.html` to replace the short bullet list with detailed `<li>` entries for five events: Madonna della Madia (Monopoli), Sant’Oronzo (Ostuni), Sagra del Polpo (Mola di Bari), La Notte della Taranta (Melpignano final) and Terraròss concerts. 
- Each entry includes a bolded title, date line, a short French description and clickable external links using `<a href="..." target="_blank" rel="noopener noreferrer">`.
- Preserved surrounding HTML structure and existing localization markers (`data-i18n` attributes) outside the modified list.

### Testing
- Searched the codebase to locate the section with `rg` and confirmed the target block was found successfully. 
- Inspected the modified lines with `nl -ba /workspace/WEDDING/localisation.html | sed -n '258,325p'` and verified the new detailed entries appear as expected. 
- Verified repository status with `git -C /workspace/WEDDING status --short` to confirm `localisation.html` was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc47fc760832c8a0a729f182cee49)