### PR TITLE
Fix mobile overflow for long location links

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -48,7 +48,7 @@
       li{margin-bottom:4px;}
       .intro{font-size:18px;color:var(--text);margin-bottom:16px;}
       .location-core{line-height:1.8;color:var(--muted);}
-      .location-link{display:inline-block;margin-top:8px;color:var(--accent-strong);text-decoration:none;}
+      .location-link{display:inline-block;max-width:100%;margin-top:8px;color:var(--accent-strong);text-decoration:none;white-space:normal;overflow-wrap:anywhere;word-break:break-word;}
       .location-link:hover{text-decoration:underline;}
       .map-layout{display:grid;grid-template-columns:minmax(280px,340px) minmax(0,1.35fr);gap:22px;align-items:stretch;margin:24px 0 10px;}
       .map{width:100%;height:clamp(420px,62vh,640px);border:1px solid var(--border);border-radius:20px;box-shadow:0 16px 30px rgba(0,0,0,.08);overflow:hidden;}


### PR DESCRIPTION
### Motivation
- Long raw URLs on the location page could overflow their container on small screens and cause the page to expand horizontally, exposing the right border.

### Description
- Tighten `.location-link` styles in `localisation.html` by adding `max-width: 100%`, `white-space: normal`, `overflow-wrap: anywhere`, and `word-break: break-word` to allow long links to wrap instead of pushing the layout.

### Testing
- Executed `git diff -- localisation.html`, inspected the modified lines with `nl -ba localisation.html | sed -n '42,58p'`, and committed the change; the commands completed successfully and no automated test suite is configured for this repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc7e7c3f0832c893e4f45f7a5d71a)