### PR TITLE
Improve long URL wrapping on localisation page

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -48,7 +48,7 @@
       li{margin-bottom:4px;}
       .intro{font-size:18px;color:var(--text);margin-bottom:16px;}
       .location-core{line-height:1.8;color:var(--muted);}
-      .location-link{display:inline-block;max-width:100%;margin-top:8px;color:var(--accent-strong);text-decoration:none;white-space:normal;overflow-wrap:anywhere;word-break:break-word;}
+      .location-link{display:inline-block;max-width:31ch;margin-top:8px;color:var(--accent-strong);text-decoration:none;white-space:normal;overflow-wrap:anywhere;word-break:break-word;}
       .location-link:hover{text-decoration:underline;}
       .map-layout{display:grid;grid-template-columns:minmax(280px,340px) minmax(0,1.35fr);gap:22px;align-items:stretch;margin:24px 0 10px;}
       .map{width:100%;height:clamp(420px,62vh,640px);border:1px solid var(--border);border-radius:20px;box-shadow:0 16px 30px rgba(0,0,0,.08);overflow:hidden;}


### PR DESCRIPTION
### Motivation
- Prevent very long URLs on the localisation page from stretching the layout by encouraging them to wrap to approximately two lines.

### Description
- Change `max-width` for the `.location-link` rule in `localisation.html` from `100%` to `31ch` so long links break earlier and fit the content area.

### Testing
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc9b7e200832c8b4a76ca93cd5f65)