### PR TITLE
Ajuste l’affichage des liens dans la section des fêtes d’août

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -49,6 +49,17 @@
       .intro{font-size:18px;color:var(--text);margin-bottom:16px;}
       .location-core{line-height:1.8;color:var(--muted);}
       .location-link{display:inline-block;max-width:31ch;margin-top:8px;color:var(--accent-strong);text-decoration:none;white-space:normal;overflow-wrap:anywhere;word-break:break-word;}
+      .festival-link{
+        display:inline-block;
+        max-width:29ch;
+        color:var(--accent-strong);
+        text-decoration:none;
+        white-space:normal;
+        overflow-wrap:anywhere;
+        word-break:break-word;
+        line-height:1.45;
+      }
+      .festival-link:hover{text-decoration:underline;}
       .location-link:hover{text-decoration:underline;}
       .map-layout{display:grid;grid-template-columns:minmax(280px,340px) minmax(0,1.35fr);gap:22px;align-items:stretch;margin:24px 0 10px;}
       .map{width:100%;height:clamp(420px,62vh,640px);border:1px solid var(--border);border-radius:20px;box-shadow:0 16px 30px rgba(0,0,0,.08);overflow:hidden;}
@@ -267,34 +278,34 @@
             <strong>Festa patronale Madonna della Madia – Monopoli</strong><br>
             📅 13 – 16 août 2026<br>
             Célébration emblématique de la ville de Monopoli, marquée par des processions, des illuminations et la reconstitution spectaculaire de l’arrivée de l’icône de la Vierge par la mer.<br>
-            🔗 <a href="https://it.wikipedia.org/wiki/Madonna_della_Madia" target="_blank" rel="noopener noreferrer">https://it.wikipedia.org/wiki/Madonna_della_Madia</a>
+            🔗 <a class="festival-link" href="https://it.wikipedia.org/wiki/Madonna_della_Madia" target="_blank" rel="noopener noreferrer">https://it.wikipedia.org/wiki/<wbr>Madonna_della_<wbr>Madia</a>
           </li>
           <li>
             <strong>Festa di Sant’Oronzo – Ostuni</strong><br>
             📅 25 – 27 août 2026<br>
             Fête patronale de la “Città Bianca”, connue pour sa célèbre cavalcade de chevaux décorés, ses illuminations et ses feux d’artifice.<br>
-            🔗 <a href="https://it.wikipedia.org/wiki/Sant%27Oronzo" target="_blank" rel="noopener noreferrer">https://it.wikipedia.org/wiki/Sant%27Oronzo</a>
+            🔗 <a class="festival-link" href="https://it.wikipedia.org/wiki/Sant%27Oronzo" target="_blank" rel="noopener noreferrer">https://it.wikipedia.org/wiki/<wbr>Sant%27<wbr>Oronzo</a>
           </li>
           <li>
             <strong>Sagra del Polpo – Mola di Bari</strong><br>
             📅 24 – 26 juillet 2026<br>
             Festival populaire dédié au poulpe, avec stands de street food, spécialités locales et ambiance festive en bord de mer.<br>
-            🔗 <a href="https://www.facebook.com/lafestadelmaremola" target="_blank" rel="noopener noreferrer">https://www.facebook.com/lafestadelmaremola</a>
+            🔗 <a class="festival-link" href="https://www.facebook.com/lafestadelmaremola" target="_blank" rel="noopener noreferrer">https://www.facebook.com/<wbr>lafestade<wbr>lmaremola</a>
           </li>
           <li>
             <strong>La Notte della Taranta – Salento (final à Melpignano)</strong><br>
             📅 22 août 2026<br>
             Concert final du plus grand festival de musique traditionnelle du sud de l’Italie, dédié à la pizzica, précédé de plusieurs soirées dans différents villages du Salento.<br>
-            🔗 <a href="https://www.lanottedellataranta.it" target="_blank" rel="noopener noreferrer">https://www.lanottedellataranta.it</a>
+            🔗 <a class="festival-link" href="https://www.lanottedellataranta.it" target="_blank" rel="noopener noreferrer">https://www.<wbr>lanottedella<wbr>taranta.it</a>
           </li>
           <li>
             <strong>Terraròss – concerts de musique populaire pugliese — chaleureusement recommandé ❤️</strong><br>
             📅 Dates été 2026 à venir<br>
             Groupe emblématique des Pouilles, les Terraròss font vivre la tradition populaire du Sud de l’Italie à travers pizzica, tarantella, tamburelli, chants et danses.<br>
             Leur calendrier est généralement publié progressivement avant l’été : nous vous conseillons de vérifier leurs prochaines dates sur leurs pages officielles.<br>
-            🔗 <a href="https://www.terraross.it/?page_id=72" target="_blank" rel="noopener noreferrer">https://www.terraross.it/?page_id=72</a><br>
-            🔗 <a href="https://www.facebook.com/TerrarossOfficial" target="_blank" rel="noopener noreferrer">https://www.facebook.com/TerrarossOfficial</a><br>
-            🔗 <a href="https://www.instagram.com/terrarossofficial/" target="_blank" rel="noopener noreferrer">https://www.instagram.com/terrarossofficial/</a>
+            🔗 <a class="festival-link" href="https://www.terraross.it/?page_id=72" target="_blank" rel="noopener noreferrer">https://www.terraross.<wbr>it/?page_<wbr>id=72</a><br>
+            🔗 <a class="festival-link" href="https://www.facebook.com/TerrarossOfficial" target="_blank" rel="noopener noreferrer">https://www.facebook.com/<wbr>Terraross<wbr>Official</a><br>
+            🔗 <a class="festival-link" href="https://www.instagram.com/terrarossofficial/" target="_blank" rel="noopener noreferrer">https://www.instagram.com/<wbr>terraross<wbr>official/</a>
           </li>
         </ul>
         <p data-i18n="location.food.outro">Musique, lumières et pure énergie du sud.</p>


### PR DESCRIPTION
### Motivation
- Empêcher que les URLs longues de la section « Fêtes d'août à ne pas manquer » n'étirent les lignes et améliorer leur lisibilité en forçant un rendu sur plusieurs lignes.

### Description
- Ajout d'une classe CSS `.festival-link` et application de cette classe à tous les liens de la section, avec `max-width` et règles de césure, et insertion de points de coupure `<wbr>` dans le texte des URLs pour forcer les retours à la ligne sans modifier les `href`.

### Testing
- `git add` / `git commit` ont été exécutés avec succès pour enregistrer les modifications.
- `xmllint --html --noout localisation.html` a été tenté mais a échoué car `xmllint` n'est pas disponible dans l'environnement (commande introuvable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcc019cfc832cb81e6d808ab9ab41)