### PR TITLE
Limiter largeur des liens sur mobile pour meilleure lisibilité

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -154,6 +154,8 @@
         .map{min-height:unset;height:380px;}
         .map-discover{min-height:unset;height:auto;box-shadow:0 10px 24px rgba(0,0,0,.08);}
         .map-discover .map-place-list{max-height:320px;min-height:190px;}
+        .location-link,
+        .festival-link{max-width:26ch;}
         .hamburger{display:inline-flex; align-items:center; justify-content:center; position:fixed; top:20px; right:20px; z-index:3001; touch-action:manipulation; width:42px; height:42px; border-radius:999px; border:1px solid var(--border); background:#fff; color:var(--text); cursor:pointer;}
         .hamburger:focus-visible{outline:3px solid var(--text); outline-offset:2px;}
         nav.topnav{display:none; position:fixed; top:70px; right:10px; z-index:3000; flex-direction:column; gap:12px; background:#fff; padding:14px; border-radius:16px; border:1px solid var(--border); box-shadow:0 12px 30px rgba(0,0,0,.12); opacity:0; visibility:hidden; pointer-events:none; transform:translateY(-10px); transition:opacity .3s ease, transform .3s ease, visibility .3s ease;}


### PR DESCRIPTION
### Motivation
- Rendre le rendu des liens plus agréable sur petits écrans en forçant un passage à la ligne plus rapide sans toucher aux URL ni aux attributs de lien.

### Description
- Ajouté dans `localisation.html` (sous `@media (max-width:768px)`) la règle CSS `max-width:26ch` pour `.location-link` et `.festival-link`, les autres styles et les hyperliens restent inchangés.

### Testing
- Exécutés des contrôles Git automatisés (`git status`, `git diff localisation.html`, `git commit`) et ils ont réussi; pas de tests unitaires ou visuels automatiques nécessaires pour ce simple ajustement CSS.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcd8f1ff8832c865681fa9c029d20)