### PR TITLE
Improve mobile text fit in location category panel

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -150,9 +150,15 @@
       .map-open-link:hover{background:var(--text);color:#fff;}
       .hamburger{display:none;}
       @media (max-width:768px){
+        main{padding:110px 14px 72px;}
+        section{padding:30px 18px;border-radius:24px;}
         .map-layout{grid-template-columns:1fr;}
         .map{min-height:unset;height:380px;}
-        .map-discover{min-height:unset;height:auto;box-shadow:0 10px 24px rgba(0,0,0,.08);}
+        .map-discover{min-height:unset;height:auto;box-shadow:0 10px 24px rgba(0,0,0,.08);padding:16px;}
+        .map-category-buttons{gap:8px;}
+        .map-category-btn{padding:7px 11px;}
+        .map-place-list{padding:6px;}
+        .map-place-item{padding:9px 10px;}
         .map-discover .map-place-list{max-height:320px;min-height:190px;}
         .location-link,
         .festival-link{max-width:26ch;}


### PR DESCRIPTION
### Motivation
- Improve mobile readability in the location page by allowing more characters per line in the category/map discovery panel without changing link styles.

### Description
- Reduced horizontal padding on `main` and `section` in the `@media (max-width:768px)` block to free up horizontal space for content. 
- Added internal spacing tweaks to `.map-discover`, `.map-category-buttons`, `.map-category-btn`, `.map-place-list`, and `.map-place-item` to reduce wrapping and fit longer labels on small screens. 
- Adjusted `section` border-radius for tighter mobile layout while preserving existing link styles (`.location-link`, `.festival-link`). 
- Changes made in `localisation.html` inside the mobile media query only.

### Testing
- Verified the diff with `git diff -- localisation.html` which shows the CSS changes and confirmed the updated lines with `nl -ba localisation.html | sed -n '145,185p'`. 
- Committed the change successfully (`git commit` returned success). 
- No automated visual or unit tests were run because this is a CSS-only mobile layout adjustment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcf6b380c832c9768651905f00a1e)