### PR TITLE
Update gift button message across all languages

### DIFF
--- a/liste-noce.html
+++ b/liste-noce.html
@@ -77,7 +77,7 @@
         <h2 data-i18n="registry.title">Liste de noce</h2>
         <p class="note" data-i18n="registry.text">Votre présence est notre plus beau cadeau. Si vous souhaitez nous gâter, voici les projets qui nous tiennent à cœur.</p>
         <p class="note" data-i18n="registry.text2">Les objets se perdent, se cassent, s’oublient. Un voyage est une émotion qui reste gravée pour toujours dans la mémoire.</p>
-        <button type="button" class="gift-toggle" id="gift-toggle" data-i18n="registry.revealButton">Si vous souhaitez nous faire un cadeau ❤️</button>
+        <button type="button" class="gift-toggle" id="gift-toggle" data-i18n="registry.revealButton">En attendant d'ouvrir notre compte bancaire commun voici l'identifiant bancaire de la mariée pour ceux qui voudraient nous offrir un cadeau</button>
         <div class="iban-card" id="iban-card" hidden>
           <p><span class="iban-label" data-i18n="registry.transferTitle">Coordonnées bancaires</span>Fidalma INTINI<br />IBAN 00443534366265235363734<br />SWIFT 0CGT67</p>
         </div>
@@ -91,7 +91,7 @@
             text: "Nous voulons remercier nos familles et nos amis pour l'amour et le soutien qu'ils nous ont témoignés au début de notre avenir ensemble. Vous avoir à nos côtés pour le plus beau jour de notre vie est déjà le plus grand des cadeaux. Mais si vous souhaitez nous aider à réaliser notre lune de miel de rêve, nous vous en serons profondément reconnaissants.",
             text2: "Les objets se perdent, se cassent, s'oublient. Un voyage est une émotion qui reste gravée pour toujours dans la mémoire. Merci à vous qui, par votre contribution, nous aiderez à réaliser le voyage de noces de nos rêves.",
             transferTitle: 'Coordonnées bancaires',
-            revealButton: 'Si vous souhaitez nous faire un cadeau ❤️'
+            revealButton: "En attendant d'ouvrir notre compte bancaire commun voici l'identifiant bancaire de la mariée pour ceux qui voudraient nous offrir un cadeau"
           },
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' }
         },
@@ -101,7 +101,7 @@
             text: "Vogliamo ringraziare le nostre famiglie e i nostri amici per l'amore e il sostegno che ci hanno dimostrato all'inizio del nostro futuro insieme. Averti con noi nel nostro giorno più bello è il regalo più grande che possiate farci, ma se volete aiutarci a realizzare la nostra luna di miele da sogno ve ne saremo profondamente grati.",
             text2: "Gli oggetti si perdono, si rompono, si dimenticano. Un viaggio è un'emozione che resta per sempre impressa nella memoria. Grazie a voi che contribuendo, ci aiuterete a realizzare il viaggio di nozze dei nostri sogni.",
             transferTitle: 'Coordinate bancarie',
-            revealButton: 'Se desiderate farci un regalo ❤️'
+            revealButton: "In attesa di aprire il nostro conto bancario comune, ecco le coordinate bancarie della sposa per chi desidera farci un regalo"
           },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'conferma' }
         },
@@ -111,7 +111,7 @@
             text: 'We want to thank our families and friends for the love and support they have shown us at the beginning of our future together. Having you with us on our most beautiful day is already the greatest gift you can give us, but if you would like to help us make our dream honeymoon come true, we would be deeply grateful.',
             text2: 'Objects get lost, broken, and forgotten. A journey is an emotion that remains forever etched in memory. Thank you for helping us bring the honeymoon of our dreams to life through your contribution.',
             transferTitle: 'Bank details',
-            revealButton: 'If you would like to give us a gift ❤️'
+            revealButton: 'While we wait to open our joint bank account, here are the bride’s bank details for those who would like to give us a gift'
           },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' }
         }


### PR DESCRIPTION
### Motivation
- Show the bride's bank details message on the gift/reveal button while the couple's joint account is not open and keep the site consistent across languages.

### Description
- Replace the inline French gift button label in `liste-noce.html` with the new longer French message.
- Update the `I18N.registry.revealButton` translation strings for `fr`, `it`, and `en` inside `liste-noce.html` so language switching displays the same intent.
- No other markup or logic changes were made.

### Testing
- Ran `git diff --check` which returned no whitespace or patch issues.
- Inspected the file diff with `git diff -- liste-noce.html` to verify the expected string replacements were the only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe1c9e174832ca105a08bd83c709f)