### PR TITLE
Fix localisation language buttons to navigate to selected language

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -825,7 +825,13 @@
         history.replaceState(null, '', `${url.pathname.split('/').pop()}${url.search}${url.hash}`);
         renderMapPlaces(lang);
       }
-      document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>applyTranslations(btn.dataset.lang)));
+      document.querySelectorAll('.lang-switch button').forEach(btn=>btn.addEventListener('click',()=>{
+        const lang = btn.dataset.lang;
+        applyTranslations(lang);
+        const url = new URL(location.href);
+        url.searchParams.set('lang', lang);
+        location.assign(`${url.pathname.split('/').pop()}${url.search}${url.hash}`);
+      }));
 
       function highlightActiveLink(){
         const current = location.pathname.split('/').pop() || 'index.html';


### PR DESCRIPTION
### Motivation
- Clicking the FR/IT/EN buttons on the Localisation page applied translations locally but did not navigate to the page URL with `?lang=...`, making the action invisible or ineffective when a full-page language URL is required.

### Description
- Updated the `.lang-switch` click handler in `localisation.html` to call `applyTranslations(lang)` and then build the page URL with `?lang=` and perform `location.assign(...)` to navigate to the selected language.
- Preserved existing translation logic and link-updating via `applyTranslations` and `updateLanguageInLinks`, and added an explicit navigation step so the selected language becomes part of the page URL.

### Testing
- Ran `rg` to locate i18n handlers and inspected the modified handler with `nl -ba localisation.html | sed -n '818,845p'`, confirming the new `location.assign(...)` call is present and the change applied successfully.
- No automated unit test suite was available for these pages; only file-level smoke checks were executed and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65c5b7054832ca5c378791afb8109)