### PR TITLE
Fix localisation page translations not loading in Italian/English

### DIFF
--- a/localisation.html
+++ b/localisation.html
@@ -375,11 +375,11 @@
               dish1: 'Orecchiette aux cime di rapa',
               dish2: 'Focaccia barese',
               festivalsLabel: 'Fêtes d\'août à ne pas manquer :',
-              fest1: { title: 'Festa patronale Madonna della Madia – Monopoli', date: '📅 13 – 16 août 2026', desc: 'Célébration emblématique de la ville de Monopoli, marquée par des processions, des illuminations et la reconstitution spectaculaire de l'arrivée de l'icône de la Vierge par la mer.' },
-              fest2: { title: 'Festa di Sant’Oronzo – Ostuni', date: '📅 25 – 27 août 2026', desc: 'Fête patronale de la “Città Bianca”, connue pour sa célèbre cavalcade de chevaux décorés, ses illuminations et ses feux d'artifice.' },
+              fest1: { title: 'Festa patronale Madonna della Madia – Monopoli', date: '📅 13 – 16 août 2026', desc: 'Célébration emblématique de la ville de Monopoli, marquée par des processions, des illuminations et la reconstitution spectaculaire de l\'arrivée de l\'icône de la Vierge par la mer.' },
+              fest2: { title: 'Festa di Sant’Oronzo – Ostuni', date: '📅 25 – 27 août 2026', desc: 'Fête patronale de la “Città Bianca”, connue pour sa célèbre cavalcade de chevaux décorés, ses illuminations et ses feux d\'artifice.' },
               fest3: { title: 'Sagra del Polpo – Mola di Bari', date: '📅 24 – 26 juillet 2026', desc: 'Festival populaire dédié au poulpe, avec stands de street food, spécialités locales et ambiance festive en bord de mer.' },
-              fest4: { title: 'La Notte della Taranta – Salento (final à Melpignano)', date: '📅 22 août 2026', desc: 'Concert final du plus grand festival de musique traditionnelle du sud de l'Italie, dédié à la pizzica, précédé de plusieurs soirées dans différents villages du Salento.' },
-              fest5: { title: 'Terraròss – concerts de musique populaire pugliese — chaleureusement recommandé ❤️', date: '📅 Dates été 2026 à venir', desc1: 'Groupe emblématique des Pouilles, les Terraròss font vivre la tradition populaire du Sud de l'Italie à travers pizzica, tarantella, tamburelli, chants et danses.', desc2: 'Leur calendrier est généralement publié progressivement avant l'été : nous vous conseillons de vérifier leurs prochaines dates sur leurs pages officielles.' },
+              fest4: { title: 'La Notte della Taranta – Salento (final à Melpignano)', date: '📅 22 août 2026', desc: 'Concert final du plus grand festival de musique traditionnelle du sud de l\'Italie, dédié à la pizzica, précédé de plusieurs soirées dans différents villages du Salento.' },
+              fest5: { title: 'Terraròss – concerts de musique populaire pugliese — chaleureusement recommandé ❤️', date: '📅 Dates été 2026 à venir', desc1: 'Groupe emblématique des Pouilles, les Terraròss font vivre la tradition populaire du Sud de l\'Italie à travers pizzica, tarantella, tamburelli, chants et danses.', desc2: 'Leur calendrier est généralement publié progressivement avant l\'été : nous vous conseillons de vérifier leurs prochaines dates sur leurs pages officielles.' },
               outro: 'Musique, lumières et pure énergie du sud.'
             }
           },
@@ -440,11 +440,11 @@
               dish1: 'Orecchiette con cime di rapa',
               dish2: 'Focaccia barese',
               festivalsLabel: 'Feste di agosto da non perdere:',
-              fest1: { title: 'Festa patronale Madonna della Madia – Monopoli', date: '📅 13–16 agosto 2026', desc: 'Celebrazione simbolo di Monopoli, con processioni, luminarie e la suggestiva rievocazione dell'arrivo via mare dell'icona della Madonna.' },
-              fest2: { title: 'Festa di Sant’Oronzo – Ostuni', date: '📅 25–27 agosto 2026', desc: 'Festa patronale della Città Bianca, nota per la cavalcata dei cavalli bardati, le luminarie e i fuochi d'artificio.' },
+              fest1: { title: 'Festa patronale Madonna della Madia – Monopoli', date: '📅 13–16 agosto 2026', desc: 'Celebrazione simbolo di Monopoli, con processioni, luminarie e la suggestiva rievocazione dell\'arrivo via mare dell\'icona della Madonna.' },
+              fest2: { title: 'Festa di Sant’Oronzo – Ostuni', date: '📅 25–27 agosto 2026', desc: 'Festa patronale della Città Bianca, nota per la cavalcata dei cavalli bardati, le luminarie e i fuochi d\'artificio.' },
               fest3: { title: 'Sagra del Polpo – Mola di Bari', date: '📅 24–26 luglio 2026', desc: 'Sagra popolare dedicata al polpo, con stand di street food, specialità locali e atmosfera festosa sul mare.' },
               fest4: { title: 'La Notte della Taranta – Salento (finale a Melpignano)', date: '📅 22 agosto 2026', desc: 'Concerto finale del più grande festival di musica tradizionale del Sud Italia dedicato alla pizzica, preceduto da serate in vari borghi del Salento.' },
-              fest5: { title: 'Terraròss – concerti di musica popolare pugliese — consigliatissimo ❤️', date: '📅 Date estate 2026 in arrivo', desc1: 'Gruppo simbolo della Puglia, i Terraròss fanno vivere la tradizione popolare del Sud Italia tra pizzica, tarantella, tamburelli, canti e danze.', desc2: 'Il calendario viene pubblicato progressivamente prima dell'estate: vi consigliamo di controllare le prossime date sulle pagine ufficiali.' },
+              fest5: { title: 'Terraròss – concerti di musica popolare pugliese — consigliatissimo ❤️', date: '📅 Date estate 2026 in arrivo', desc1: 'Gruppo simbolo della Puglia, i Terraròss fanno vivere la tradizione popolare del Sud Italia tra pizzica, tarantella, tamburelli, canti e danze.', desc2: 'Il calendario viene pubblicato progressivamente prima dell\'estate: vi consigliamo di controllare le prossime date sulle pagine ufficiali.' },
               outro: 'Musica, luci e pura energia del sud.'
             }
           },
@@ -505,10 +505,10 @@
               dish1: 'Orecchiette with cime di rapa',
               dish2: 'Focaccia barese',
               festivalsLabel: 'August festivals not to miss:',
-              fest1: { title: 'Patronal Festival of Madonna della Madia – Monopoli', date: '📅 August 13–16, 2026', desc: 'Monopoli's signature celebration, with processions, light displays, and a striking reenactment of the Virgin's icon arriving by sea.' },
+              fest1: { title: 'Patronal Festival of Madonna della Madia – Monopoli', date: '📅 August 13–16, 2026', desc: 'Monopoli\'s signature celebration, with processions, light displays, and a striking reenactment of the Virgin\'s icon arriving by sea.' },
               fest2: { title: 'Festa di Sant’Oronzo – Ostuni', date: '📅 August 25–27, 2026', desc: 'Patron saint festival of the White City, known for its decorated horse parade, illuminations, and fireworks.' },
               fest3: { title: 'Sagra del Polpo – Mola di Bari', date: '📅 July 24–26, 2026', desc: 'A popular octopus festival with street-food stands, local specialties, and a lively seaside atmosphere.' },
-              fest4: { title: 'La Notte della Taranta – Salento (final in Melpignano)', date: '📅 August 22, 2026', desc: 'Final concert of Southern Italy's largest traditional music festival dedicated to pizzica, preceded by events across Salento villages.' },
+              fest4: { title: 'La Notte della Taranta – Salento (final in Melpignano)', date: '📅 August 22, 2026', desc: 'Final concert of Southern Italy\'s largest traditional music festival dedicated to pizzica, preceded by events across Salento villages.' },
               fest5: { title: 'Terraròss – Puglian folk music concerts — highly recommended ❤️', date: '📅 Summer 2026 dates coming soon', desc1: 'An iconic Puglian group, Terraròss keeps Southern Italian folk traditions alive through pizzica, tarantella, tamburelli, singing, and dance.', desc2: 'Their schedule is usually released gradually before summer: we recommend checking upcoming dates on their official pages.' },
               outro: 'Music, lights and pure southern energy.'
             }


### PR DESCRIPTION
### Motivation
- The language switcher on `localisation.html` was failing because unescaped single quotes inside the inline `I18N` object caused a JavaScript syntax error, which made the EN/IT buttons appear non-functional.

### Description
- Escaped problematic single quotes in festival-related translation strings for `fr`, `it` and `en` inside `localisation.html` to produce valid JavaScript string literals. 
- Kept the change localized to the inline `<script>` I18N object and updated only `localisation.html`.
- Ensured the map/place i18n logic and label templates remain unchanged except for the string escaping.

### Testing
- Extracted the inline `<script>` into `/tmp/localisation.js` using a small Python snippet and validated syntax with `node --check`, which reported no errors. 
- Verified the inline script re-check returned success after the fixes, confirming the JavaScript parse errors were resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6656d7e24832ca64913e41fbae851)