### PR TITLE
Capitalize Italian 'Conferma' labels in navigation and RSVP

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,8 +160,8 @@
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
           info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'conferma' },
-          rsvp: { title: 'conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',

--- a/info.html
+++ b/info.html
@@ -131,8 +131,8 @@
             contactsTitle: 'Contatti',
             contactEmailLabel: 'Email :'
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'conferma' },
-          rsvp: { title: 'conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',

--- a/liste-noce.html
+++ b/liste-noce.html
@@ -103,7 +103,7 @@
             transferTitle: 'Coordinate bancarie',
             revealButton: "In attesa di aprire il nostro conto bancario comune, ecco le coordinate bancarie della sposa per chi desidera farci un regalo"
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'conferma' }
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' }
         },
         en: {
           registry: {

--- a/localisation.html
+++ b/localisation.html
@@ -448,8 +448,8 @@
               outro: 'Musica, luci e pura energia del sud.'
             }
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'conferma' },
-          rsvp: { title: 'conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',

--- a/rsvp.html
+++ b/rsvp.html
@@ -84,8 +84,8 @@
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'conferma' },
-          rsvp: { title: 'conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',

--- a/wedding.html
+++ b/wedding.html
@@ -229,8 +229,8 @@
             party_note: 'Pista da ballo aperta fino a tardi.'
           },
           location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'conferma' },
-          rsvp: { title: 'conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',


### PR DESCRIPTION
### Motivation
- Ensure the Italian UI uses a capitalized `Conferma` for consistency in navigation labels and RSVP titles.

### Description
- Replaced lowercase `conferma` with `Conferma` in the Italian `nav.rsvp` and `rsvp.title` localization entries across site pages.
- Changes applied to the following files: `index.html`, `info.html`, `localisation.html`, `rsvp.html`, `wedding.html`, and `liste-noce.html`.

### Testing
- Ran `rg -n "conferma|Conferma"` to locate occurrences and confirm replacements; results show updated `Conferma` in the targeted contexts.
- Reviewed the diffs with `git diff -- localisation.html info.html rsvp.html index.html liste-noce.html wedding.html` to verify only the intended strings changed.
- Displayed updated file snippets with `nl` to visually confirm the new `Conferma` labels; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa35304544832ca67275da24c48db0)