### PR TITLE
Remove bank details from registry and polish multilingual copy

### DIFF
--- a/liste-noce.html
+++ b/liste-noce.html
@@ -35,13 +35,7 @@
       ul li{padding:8px 0;position:relative;}
       ul li::before{content:"•";color:var(--muted);display:inline-block;width:18px;margin-left:-18px;}
       .note{max-width:680px;margin:0 auto 18px;line-height:1.7;font-size:18px;color:var(--muted);}
-      .iban-card{max-width:640px;margin:26px auto 0;padding:18px 20px;border:1px solid var(--border);border-radius:16px;background:linear-gradient(180deg,#fff,#f9f9fb);text-align:left;box-shadow:0 10px 25px rgba(0,0,0,.05);}
-      .iban-card p{margin:0;color:var(--text);line-height:1.6;font-size:16px;}
-      .iban-card .iban-label{display:block;color:var(--muted);font-size:13px;letter-spacing:.04em;text-transform:uppercase;margin-bottom:8px;}
-      .gift-toggle{margin:22px auto 0;display:inline-flex;align-items:center;justify-content:center;padding:11px 22px;border-radius:999px;border:1px solid var(--text);background:#fff;color:var(--text);font-weight:500;cursor:pointer;transition:all .3s ease;}
-      .gift-toggle:hover{background:var(--text);color:#fff;}
-      .gift-toggle:focus-visible{outline:3px solid var(--accent-strong);outline-offset:2px;}
-      .iban-card[hidden]{display:none;}
+      .bank-note{margin:22px auto 0;max-width:700px;padding:16px 20px;border:1px solid var(--border);border-radius:16px;background:#fff;color:var(--text);font-size:17px;line-height:1.65;}
       .hamburger{display:none;}
       @media (max-width:768px){
         .lang-switch{position:absolute; top:20px; left:16px; z-index:3;}
@@ -77,10 +71,7 @@
         <h2 data-i18n="registry.title">Liste de noce</h2>
         <p class="note" data-i18n="registry.text">Votre présence est notre plus beau cadeau. Si vous souhaitez nous gâter, voici les projets qui nous tiennent à cœur.</p>
         <p class="note" data-i18n="registry.text2">Les objets se perdent, se cassent, s’oublient. Un voyage est une émotion qui reste gravée pour toujours dans la mémoire.</p>
-        <button type="button" class="gift-toggle" id="gift-toggle" data-i18n="registry.revealButton">En attendant d'ouvrir notre compte bancaire commun voici l'identifiant bancaire de la mariée pour ceux qui voudraient nous offrir un cadeau</button>
-        <div class="iban-card" id="iban-card" hidden>
-          <p><span class="iban-label" data-i18n="registry.transferTitle">Coordonnées bancaires</span>Fidalma INTINI<br />IBAN 00443534366265235363734<br />SWIFT 0CGT67</p>
-        </div>
+        <p class="bank-note" data-i18n="registry.bankLater">Les données bancaires seront ajoutées plus tard. Merci pour votre patience et votre générosité.</p>
       </section>
     </main>
     <script>
@@ -89,19 +80,17 @@
           registry: {
             title: 'Liste de noce',
             text: "Nous voulons remercier nos familles et nos amis pour l'amour et le soutien qu'ils nous ont témoignés au début de notre avenir ensemble. Vous avoir à nos côtés pour le plus beau jour de notre vie est déjà le plus grand des cadeaux. Mais si vous souhaitez nous aider à réaliser notre lune de miel de rêve, nous vous en serons profondément reconnaissants.",
-            text2: "Les objets se perdent, se cassent, s'oublient. Un voyage est une émotion qui reste gravée pour toujours dans la mémoire. Merci à vous qui, par votre contribution, nous aiderez à réaliser le voyage de noces de nos rêves.",
-            transferTitle: 'Coordonnées bancaires',
-            revealButton: "En attendant d'ouvrir notre compte bancaire commun voici l'identifiant bancaire de la mariée pour ceux qui voudraient nous offrir un cadeau"
+            text2: "Les objets se perdent, se cassent et s'oublient. Un voyage est une émotion qui reste gravée à jamais dans la mémoire. Merci à vous qui, par votre contribution, nous aiderez à réaliser le voyage de noces de nos rêves.",
+            bankLater: "Les données bancaires seront ajoutées plus tard. Merci pour votre patience et votre générosité."
           },
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' }
         },
         it: {
           registry: {
             title: 'Lista nozze',
-            text: "Vogliamo ringraziare le nostre famiglie e i nostri amici per l'amore e il sostegno che ci hanno dimostrato all'inizio del nostro futuro insieme. Averti con noi nel nostro giorno più bello è il regalo più grande che possiate farci, ma se volete aiutarci a realizzare la nostra luna di miele da sogno ve ne saremo profondamente grati.",
-            text2: "Gli oggetti si perdono, si rompono, si dimenticano. Un viaggio è un'emozione che resta per sempre impressa nella memoria. Grazie a voi che contribuendo, ci aiuterete a realizzare il viaggio di nozze dei nostri sogni.",
-            transferTitle: 'Coordinate bancarie',
-            revealButton: "In attesa di aprire il nostro conto bancario comune, ecco le coordinate bancarie della sposa per chi desidera farci un regalo"
+            text: "Vogliamo ringraziare le nostre famiglie e i nostri amici per l'amore e il sostegno che ci hanno dimostrato all'inizio del nostro futuro insieme. Averti con noi nel giorno più bello della nostra vita è già il regalo più grande che possiate farci, ma se volete aiutarci a realizzare la nostra luna di miele da sogno, ve ne saremo profondamente grati.",
+            text2: "Gli oggetti si perdono, si rompono e si dimenticano. Un viaggio è un'emozione che resta per sempre impressa nella memoria. Grazie a voi che, con il vostro contributo, ci aiuterete a realizzare il viaggio di nozze dei nostri sogni.",
+            bankLater: "I dati bancari saranno aggiunti più avanti. Grazie per la vostra pazienza e generosità."
           },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' }
         },
@@ -109,9 +98,8 @@
           registry: {
             title: 'Wedding list',
             text: 'We want to thank our families and friends for the love and support they have shown us at the beginning of our future together. Having you with us on our most beautiful day is already the greatest gift you can give us, but if you would like to help us make our dream honeymoon come true, we would be deeply grateful.',
-            text2: 'Objects get lost, broken, and forgotten. A journey is an emotion that remains forever etched in memory. Thank you for helping us bring the honeymoon of our dreams to life through your contribution.',
-            transferTitle: 'Bank details',
-            revealButton: 'While we wait to open our joint bank account, here are the bride’s bank details for those who would like to give us a gift'
+            text2: 'Objects get lost, get broken, and are forgotten. A journey is an emotion that remains forever etched in memory. Thank you for helping us bring the honeymoon of our dreams to life through your contribution.',
+            bankLater: 'Bank details will be added later. Thank you for your patience and generosity.'
           },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' }
         }
@@ -182,18 +170,7 @@
         }));
       }
 
-      const giftToggle = document.getElementById('gift-toggle');
-      const ibanCard = document.getElementById('iban-card');
-      if (giftToggle && ibanCard){
-        giftToggle.addEventListener('click', ()=>{
-          const willShow = ibanCard.hasAttribute('hidden');
-          if (willShow){
-            ibanCard.removeAttribute('hidden');
-          } else {
-            ibanCard.setAttribute('hidden', '');
-          }
-        });
-      }
+
 
     </script>
   </body>


### PR DESCRIPTION
### Motivation
- Remove explicit bank identifiers from the wedding registry page and replace the interactive reveal with a neutral message indicating banking details will be provided later for privacy and clarity. 
- Improve spelling, grammar and phrasing across French, Italian and English registry copy for a more natural, consistent presentation.

### Description
- Deleted the interactive bank-details button and IBAN/SWIFT block from `liste-noce.html` and replaced them with a neutral inline message (`.bank-note`) stating that bank details will be added later. 
- Removed unused CSS rules for the old `.iban-card` / `.gift-toggle` and added a `.bank-note` style for the new message. 
- Removed the JavaScript toggle logic that handled showing/hiding the bank card. 
- Updated the i18n registry strings in French, Italian and English to correct orthography, grammar and wording and added the `bankLater` key used by the new message.

### Testing
- Verified the updated HTML structure and the presence of the new `.bank-note` element and `bankLater` i18n keys in `liste-noce.html`. 
- Inspected the file output using `nl -ba liste-noce.html | sed -n '30,220p'` to confirm the expected changes were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba17aeb9c832ca777bf1da361cfcb)