### PR TITLE
Update registry bank button copy in Italian and English

### DIFF
--- a/liste-noce.html
+++ b/liste-noce.html
@@ -94,7 +94,7 @@
             title: 'Lista nozze',
             text: "Vogliamo ringraziare le nostre famiglie e i nostri amici per l'amore e il sostegno che ci hanno dimostrato all'inizio del nostro futuro insieme. Averti con noi nel giorno più bello della nostra vita è già il regalo più grande che possiate farci, ma se volete aiutarci a realizzare la nostra luna di miele da sogno, ve ne saremo profondamente grati.",
             text2: "Gli oggetti si perdono, si rompono e si dimenticano. Un viaggio è un'emozione che resta per sempre impressa nella memoria. Grazie a voi che, con il vostro contributo, ci aiuterete a realizzare il viaggio di nozze dei nostri sogni.",
-            bankButton: "In attesa di aprire un conto comune ecc...",
+            bankButton: "In attesa dell’apertura del nostro conto comune, se lo desiderate, potete utilizzare qui sotto le coordinate bancarie della sposa.",
             bankLater: "I dati bancari saranno aggiunti più avanti. Grazie per la vostra pazienza e generosità."
           },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' }
@@ -104,7 +104,7 @@
             title: 'Wedding list',
             text: 'We want to thank our families and friends for the love and support they have shown us at the beginning of our future together. Having you with us on our most beautiful day is already the greatest gift you can give us, but if you would like to help us make our dream honeymoon come true, we would be deeply grateful.',
             text2: 'Objects get lost, get broken, and are forgotten. A journey is an emotion that remains forever etched in memory. Thank you for helping us bring the honeymoon of our dreams to life through your contribution.',
-            bankButton: 'While we wait to open a joint account, etc...',
+            bankButton: 'While we wait for our joint account to be opened, if you wish, you can use the bride’s bank details below.',
             bankLater: 'Bank details will be added later. Thank you for your patience and generosity.'
           },
           nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' }


### PR DESCRIPTION
### Motivation
- Align Italian and English translations of the registry bank button with the recently updated French copy to provide consistent messaging across locales.

### Description
- Updated the `registry.bankButton` text for `it` and `en` in `liste-noce.html` to match the French wording; no other code or markup was modified.

### Testing
- No automated tests are configured for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba927986c832c8c72dc0d8d592153)