### PR TITLE
Update Puglia section copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
       <nav class="topnav" id="topnav">
         <a href="index.html" data-i18n="nav.home">Accueil</a>
         <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-        <a href="localisation.html" data-i18n="nav.location">Localisation</a>
+        <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
         <a href="info.html" data-i18n="nav.info">Informations</a>
         <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
         <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
@@ -148,9 +148,9 @@
           cta: 'Confirmer ma venue',
           countdown: { days: 'Jours', hours: 'Heures', minutes: 'Minutes', seconds: 'Secondes' },
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
-          location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italie'},
           info: { title: 'Informations', text: 'Les détails pratiques seront ajoutés prochainement.' },
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
@@ -158,9 +158,9 @@
           cta: 'Confermare la presenza',
           countdown: { days: 'Giorni', hours: 'Ore', minutes: 'Minuti', seconds: 'Secondi' },
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
-          location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italia'},
           info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
           rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
@@ -168,9 +168,9 @@
           cta: 'Confirm attendance',
           countdown: { days: 'Days', hours: 'Hours', minutes: 'Minutes', seconds: 'Seconds' },
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
-          location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italy'},
           info: { title: 'Information', text: 'Practical details will be added soon.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };

--- a/info.html
+++ b/info.html
@@ -64,7 +64,7 @@
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-      <a href="localisation.html" data-i18n="nav.location">Localisation</a>
+      <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
       <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
@@ -99,7 +99,7 @@
           date: '08 août 2026 · Castello Marchione',
           cta: 'Confirmer ma venue',
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
-          location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italie'},
           info: {
             title: 'Informations',
             intro: 'Voici quelques informations utiles pour profiter pleinement de la journée.',
@@ -113,14 +113,14 @@
             contactsTitle: 'Contacts',
             contactEmailLabel: 'Email :'
           },
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
-          location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italia'},
           info: {
             title: 'Informazioni',
             intro: 'Ecco alcune informazioni utili per vivere al meglio la giornata.',
@@ -134,14 +134,14 @@
             contactsTitle: 'Contatti',
             contactEmailLabel: 'Email :'
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
           rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
           cta: 'Confirm attendance',
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
-          location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italy'},
           info: {
             title: 'Information',
             intro: 'Here are a few practical details to help you enjoy the day.',
@@ -155,7 +155,7 @@
             contactsTitle: 'Contacts',
             contactEmailLabel: 'Email:'
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };

--- a/liste-noce.html
+++ b/liste-noce.html
@@ -63,7 +63,7 @@
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-      <a href="localisation.html" data-i18n="nav.location">Localisation</a>
+      <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
       <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
@@ -87,7 +87,7 @@
             bankButton: "En attendant l’ouverture de notre compte commun, vous pouvez, si vous le souhaitez, utiliser les coordonnées bancaires de la mariée ci-dessous.",
             bankLater: "Les données bancaires seront ajoutées plus tard. Merci pour votre patience et votre générosité."
           },
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' }
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' }
         },
         it: {
           registry: {
@@ -97,7 +97,7 @@
             bankButton: "In attesa dell’apertura del nostro conto comune, se lo desiderate, potete utilizzare qui sotto le coordinate bancarie della sposa.",
             bankLater: "I dati bancari saranno aggiunti più avanti. Grazie per la vostra pazienza e generosità."
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' }
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' }
         },
         en: {
           registry: {
@@ -107,7 +107,7 @@
             bankButton: 'While we wait for our joint account to be opened, if you wish, you can use the bride’s bank details below.',
             bankLater: 'Bank details will be added later. Thank you for your patience and generosity.'
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' }
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' }
         }
       };
       const SUPPORTED_LANGS = Object.keys(I18N);

--- a/localisation.html
+++ b/localisation.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Localisation — Fidalma & Ilyes</title>
+    <title>PUGLIA — Fidalma & Ilyes</title>
     <link rel="icon" type="image/svg+xml" href="olivier.svg?v=1" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -47,6 +47,10 @@
       ul{margin:8px 0 0 18px;color:var(--muted);line-height:1.7;}
       li{margin-bottom:4px;}
       .intro{font-size:18px;color:var(--text);margin-bottom:16px;}
+      .puglia-intro{margin:0 0 30px;padding-bottom:24px;border-bottom:1px solid var(--border);}
+      .puglia-intro h3{margin-top:0;}
+      .puglia-intro p{font-size:17px;line-height:1.75;color:var(--text);}
+      .puglia-intro p:last-child{margin-bottom:0;}
       .location-core{line-height:1.8;color:var(--muted);}
       .location-link{display:inline-block;max-width:31ch;margin-top:8px;color:var(--accent-strong);text-decoration:none;white-space:normal;overflow-wrap:anywhere;word-break:break-word;}
       .festival-link{
@@ -183,14 +187,19 @@
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-      <a href="localisation.html" data-i18n="nav.location">Localisation</a>
+      <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
       <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
     </nav>
     <main>
       <section id="localisation">
-        <h2 data-i18n="location.title">Localisation</h2>
+        <h2 data-i18n="location.title">PUGLIA</h2>
+        <div class="puglia-intro">
+          <h3 data-i18n="location.puglia.title">Les Pouilles</h3>
+          <p data-i18n="location.puglia.text1">Nous sommes heureux de vous accueillir dans les Pouilles, une terre lumineuse entre soleil, oliviers, cuisine authentique, mer cristalline et villages blancs à couper le souffle.</p>
+          <p data-i18n="location.puglia.text2">Notre mariage se déroulera au Castello Marchione, à Conversano, au cœur de la région.</p>
+        </div>
         <p class="intro" data-i18n="location.hero"></p>
         <p class="location-core" data-i18n="location.core.line1">Castello Marchione</p>
         <p class="location-core" data-i18n="location.core.line2">Italie du Sud</p>
@@ -326,7 +335,12 @@
           cta: 'Confirmer ma venue',
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: {
-            title: 'Localisation',
+            title: 'PUGLIA',
+            puglia: {
+              title: 'Les Pouilles',
+              text1: 'Nous sommes heureux de vous accueillir dans les Pouilles, une terre lumineuse entre soleil, oliviers, cuisine authentique, mer cristalline et villages blancs à couper le souffle.',
+              text2: 'Notre mariage se déroulera au Castello Marchione, à Conversano, au cœur de la région.'
+            },
             hero: '',
             core: { line1: 'Castello Marchione', line2: 'Italie du Sud', line3: 'Strada Provinciale 101, km 6.400', line4: '70014 Conversano (Bari) Puglia', line5: '16h30' },
             mapsLabel: '📍 Google Maps :',
@@ -383,7 +397,7 @@
               outro: 'Musique, lumières et pure énergie du sud.'
             }
           },
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
@@ -391,7 +405,12 @@
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: {
-            title: 'Come arrivare',
+            title: 'PUGLIA',
+            puglia: {
+              title: 'La Puglia',
+              text1: 'Siamo felici di accogliervi in Puglia, una terra luminosa tra sole, ulivi, cucina genuina, mare cristallino e borghi bianchi da togliere il fiato.',
+              text2: 'Il nostro matrimonio si svolgerà presso Castello Marchione, a Conversano, nel cuore della regione.'
+            },
             hero: 'Dove diremo «sì»',
             core: { line1: 'Castello Marchione', line2: 'Sud Italia', line3: 'Strada Provinciale 101, km 6.400', line4: '70014 Conversano (Bari) Puglia', line5: '16:30' },
             mapsLabel: '📍 Google Maps:',
@@ -448,7 +467,7 @@
               outro: 'Musica, luci e pura energia del sud.'
             }
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
           rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
@@ -456,7 +475,12 @@
           cta: 'Confirm attendance',
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
           location: {
-            title: 'Location',
+            title: 'PUGLIA',
+            puglia: {
+              title: 'Puglia',
+              text1: 'We are delighted to welcome you to Puglia, a radiant land of sunshine, olive trees, authentic cuisine, crystal-clear sea and breathtaking white villages.',
+              text2: 'Our wedding will take place at Castello Marchione, in Conversano, in the heart of the region.'
+            },
             hero: 'Where we will say “I do”',
             core: { line1: 'Castello Marchione', line2: 'Southern Italy', line3: 'Strada Provinciale 101, km 6.400', line4: '70014 Conversano (Bari) Puglia', line5: '4:30 p.m.' },
             mapsLabel: '📍 Google Maps:',
@@ -513,7 +537,7 @@
               outro: 'Music, lights and pure southern energy.'
             }
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };

--- a/rsvp.html
+++ b/rsvp.html
@@ -57,7 +57,7 @@
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-      <a href="localisation.html" data-i18n="nav.location">Localisation</a>
+      <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
       <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
@@ -75,24 +75,24 @@
           date: '08 août 2026 · Castello Marchione',
           cta: 'Confirmer ma venue',
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
-          location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italie'},
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
-          location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italia'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
           rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
           cta: 'Confirm attendance',
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
-          location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italy'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };

--- a/wedding.html
+++ b/wedding.html
@@ -131,7 +131,7 @@
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-      <a href="localisation.html" data-i18n="nav.location">Localisation</a>
+      <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
       <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
@@ -207,8 +207,8 @@
             party: 'Festa & DJ set',
             party_note: 'Dance floor ouvert jusque tard dans la nuit.'
           },
-          location: { title: 'Localisation', text: 'Castello Marchione, Conversano, Italie'},
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Localisation', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italie'},
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
@@ -228,8 +228,8 @@
             party: 'Festa & DJ set',
             party_note: 'Pista da ballo aperta fino a tardi.'
           },
-          location: { title: 'Come arrivare', text: 'Castello Marchione, Conversano, Italia'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Come arrivare', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italia'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
           rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
@@ -249,8 +249,8 @@
             party: 'Party & DJ set',
             party_note: 'Dance floor open late into the night.'
           },
-          location: { title: 'Location', text: 'Castello Marchione, Conversano, Italy'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'Location', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
+          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italy'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };


### PR DESCRIPTION
## Summary
- Rename the location navigation label to `PUGLIA` across all language versions.
- Add the translated Puglia intro copy at the top of `localisation.html`.
- Update the localisation page title and translated section title to `PUGLIA`.

## Verification
- Ran `git diff --check` successfully.
- Attempted local browser verification, but the in-app browser runtime failed to start in this environment.