### PR TITLE
Remove WhatsApp RSVP note

### DIFF
--- a/info.html
+++ b/info.html
@@ -79,8 +79,7 @@
           <article class="info-block">
             <h3 data-i18n="info.rsvp.title">RSVP</h3>
             <p data-i18n="info.rsvp.p1">Nous vous demandons de confirmer votre présence avant le 30 juin 2026 via le formulaire RSVP sur ce site.</p>
-            <p data-i18n="info.rsvp.p2">Un message sur WhatsApp nous fera plaisir, mais il ne remplace pas le formulaire RSVP.</p>
-            <p data-i18n="info.rsvp.p3">Dans le formulaire, vous pourrez indiquer qui viendra avec vous ainsi que d’éventuelles restrictions alimentaires, allergies ou besoins particuliers, afin que nous puissions les communiquer au chef avec le bon délai.</p>
+            <p data-i18n="info.rsvp.p2">Dans le formulaire, vous pourrez indiquer qui viendra avec vous ainsi que d’éventuelles restrictions alimentaires, allergies ou besoins particuliers, afin que nous puissions les communiquer au chef avec le bon délai.</p>
           </article>
           <article class="info-block">
             <h3 data-i18n="info.arrival.title">Heure d’arrivée</h3>
@@ -149,8 +148,7 @@
             rsvp: {
               title: 'RSVP',
               p1: 'Nous vous demandons de confirmer votre présence avant le 30 juin 2026 via le formulaire RSVP sur ce site.',
-              p2: 'Un message sur WhatsApp nous fera plaisir, mais il ne remplace pas le formulaire RSVP.',
-              p3: 'Dans le formulaire, vous pourrez indiquer qui viendra avec vous ainsi que d’éventuelles restrictions alimentaires, allergies ou besoins particuliers, afin que nous puissions les communiquer au chef avec le bon délai.'
+              p2: 'Dans le formulaire, vous pourrez indiquer qui viendra avec vous ainsi que d’éventuelles restrictions alimentaires, allergies ou besoins particuliers, afin que nous puissions les communiquer au chef avec le bon délai.'
             },
             arrival: {
               title: 'Heure d’arrivée',
@@ -211,8 +209,7 @@
             rsvp: {
               title: 'RSVP',
               p1: 'Vi chiediamo di confermare la vostra presenza entro il 30 giugno 2026 tramite il modulo RSVP su questo sito.',
-              p2: 'Un messaggio su WhatsApp ci farà piacere, ma non sostituisce il modulo RSVP.',
-              p3: 'Nel modulo potrete indicare chi verrà con voi ed eventuali restrizioni alimentari, allergie o esigenze particolari, così da permetterci di comunicarle allo chef con il giusto anticipo.'
+              p2: 'Nel modulo potrete indicare chi verrà con voi ed eventuali restrizioni alimentari, allergie o esigenze particolari, così da permetterci di comunicarle allo chef con il giusto anticipo.'
             },
             arrival: {
               title: 'Orario di arrivo',
@@ -273,8 +270,7 @@
             rsvp: {
               title: 'RSVP',
               p1: 'Please confirm your attendance by June 30, 2026 using the RSVP form on this website.',
-              p2: 'A WhatsApp message will make us happy, but it does not replace the RSVP form.',
-              p3: 'In the form, you will be able to indicate who will come with you and any dietary restrictions, allergies, or special needs, so we can share them with the chef with enough notice.'
+              p2: 'In the form, you will be able to indicate who will come with you and any dietary restrictions, allergies, or special needs, so we can share them with the chef with enough notice.'
             },
             arrival: {
               title: 'Arrival time',


### PR DESCRIPTION
## Summary
- Remove the WhatsApp RSVP note from the Information page in FR, IT, and EN.
- Keep the remaining RSVP guidance and contact section unchanged.

## Verification
- Ran `git diff --check` successfully.
- Parsed the inline script with Node successfully.