### PR TITLE
Update wedding list copy

### DIFF
--- a/liste-noce.html
+++ b/liste-noce.html
@@ -71,9 +71,10 @@
     <main>
       <section id="liste-noce">
         <h2 data-i18n="registry.title">Liste de noce</h2>
-        <p class="note" data-i18n="registry.text">Votre présence est notre plus beau cadeau. Si vous souhaitez nous gâter, voici les projets qui nous tiennent à cœur.</p>
-        <p class="note" data-i18n="registry.text2">Les objets se perdent, se cassent, s’oublient. Un voyage est une émotion qui reste gravée pour toujours dans la mémoire.</p>
-        <button type="button" class="bank-toggle" data-i18n="registry.bankButton">En attendant l’ouverture de notre compte commun, vous pouvez, si vous le souhaitez, utiliser les coordonnées bancaires de la mariée ci-dessous.</button>
+        <p class="note" data-i18n="registry.text">Spoiler : il n’y en a pas. Pas de liste, pas de registre, pas de « troisième service d’assiettes qu’on n’utilisera jamais ».</p>
+        <p class="note" data-i18n="registry.text2">Ce que nous voulons vraiment est simple : vous, là avec nous, en train de danser au château... et un voyage de noces incroyable.</p>
+        <p class="note" data-i18n="registry.text3">Nous n’achèterons rien d’utile : seulement des couchers de soleil dans des endroits perdus, des cabanes sur la mer et des aventures dans le désert.</p>
+        <button type="button" class="bank-toggle" data-i18n="registry.bankButton">Pour celles et ceux qui souhaitent participer, voici les coordonnées de la mariée. Le compte commun arrive bientôt, mais nous sommes déjà opérationnels et, comme d’habitude, nos valises sont déjà prêtes.</button>
         <p class="bank-note" data-i18n="registry.bankLater" hidden>Les données bancaires seront ajoutées plus tard. Merci pour votre patience et votre générosité.</p>
       </section>
     </main>
@@ -82,9 +83,10 @@
         fr: {
           registry: {
             title: 'Liste de noce',
-            text: "Nous voulons remercier nos familles et nos amis pour l'amour et le soutien qu'ils nous ont témoignés au début de notre avenir ensemble. Vous avoir à nos côtés pour le plus beau jour de notre vie est déjà le plus grand des cadeaux. Mais si vous souhaitez nous aider à réaliser notre lune de miel de rêve, nous vous en serons profondément reconnaissants.",
-            text2: "Les objets se perdent, se cassent et s'oublient. Un voyage est une émotion qui reste gravée à jamais dans la mémoire. Merci à vous qui, par votre contribution, nous aiderez à réaliser le voyage de noces de nos rêves.",
-            bankButton: "En attendant l’ouverture de notre compte commun, vous pouvez, si vous le souhaitez, utiliser les coordonnées bancaires de la mariée ci-dessous.",
+            text: "Spoiler : il n’y en a pas. Pas de liste, pas de registre, pas de « troisième service d’assiettes qu’on n’utilisera jamais ».",
+            text2: "Ce que nous voulons vraiment est simple : vous, là avec nous, en train de danser au château... et un voyage de noces incroyable.",
+            text3: "Nous n’achèterons rien d’utile : seulement des couchers de soleil dans des endroits perdus, des cabanes sur la mer et des aventures dans le désert.",
+            bankButton: "Pour celles et ceux qui souhaitent participer, voici les coordonnées de la mariée. Le compte commun arrive bientôt, mais nous sommes déjà opérationnels et, comme d’habitude, nos valises sont déjà prêtes.",
             bankLater: "Les données bancaires seront ajoutées plus tard. Merci pour votre patience et votre générosité."
           },
           nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' }
@@ -92,9 +94,10 @@
         it: {
           registry: {
             title: 'Lista nozze',
-            text: "Vogliamo ringraziare le nostre famiglie e i nostri amici per l'amore e il sostegno che ci hanno dimostrato all'inizio del nostro futuro insieme. Averti con noi nel giorno più bello della nostra vita è già il regalo più grande che possiate farci, ma se volete aiutarci a realizzare la nostra luna di miele da sogno, ve ne saremo profondamente grati.",
-            text2: "Gli oggetti si perdono, si rompono e si dimenticano. Un viaggio è un'emozione che resta per sempre impressa nella memoria. Grazie a voi che, con il vostro contributo, ci aiuterete a realizzare il viaggio di nozze dei nostri sogni.",
-            bankButton: "In attesa dell’apertura del nostro conto comune, se lo desiderate, potete utilizzare qui sotto le coordinate bancarie della sposa.",
+            text: "Spoiler: non c’è. Niente liste, niente registri, niente “terzo set di piatti che non useremo mai”.",
+            text2: "Quello che vogliamo davvero è semplice: voi lì con noi a ballare al Castello... e un viaggio di nozze da urlo.",
+            text3: "Non compreremo niente di utile: solo tramonti in posti sperduti, capanne sul mare e avventure nel deserto.",
+            bankButton: "Per chi vuole partecipare, ecco le coordinate della sposa. Il conto comune è in arrivo, ma siamo già operativi e, come al solito, abbiamo le valigie già pronte.",
             bankLater: "I dati bancari saranno aggiunti più avanti. Grazie per la vostra pazienza e generosità."
           },
           nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' }
@@ -102,9 +105,10 @@
         en: {
           registry: {
             title: 'Wedding list',
-            text: 'We want to thank our families and friends for the love and support they have shown us at the beginning of our future together. Having you with us on our most beautiful day is already the greatest gift you can give us, but if you would like to help us make our dream honeymoon come true, we would be deeply grateful.',
-            text2: 'Objects get lost, get broken, and are forgotten. A journey is an emotion that remains forever etched in memory. Thank you for helping us bring the honeymoon of our dreams to life through your contribution.',
-            bankButton: 'While we wait for our joint account to be opened, if you wish, you can use the bride’s bank details below.',
+            text: 'Spoiler: there isn’t one. No lists, no registries, no “third set of plates we will never use”.',
+            text2: 'What we truly want is simple: you there with us, dancing at the castle... and an epic honeymoon.',
+            text3: 'We will not buy anything useful: only sunsets in remote places, huts by the sea, and adventures in the desert.',
+            bankButton: 'For anyone who would like to contribute, here are the bride’s bank details. The joint account is on its way, but we are already operational and, as usual, our suitcases are already packed.',
             bankLater: 'Bank details will be added later. Thank you for your patience and generosity.'
           },
           nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' }


### PR DESCRIPTION
## Summary
- Replace the wedding list copy with the new honeymoon-focused message.
- Add translated FR, IT, and EN versions.
- Keep the bank-details reveal behavior in place.

## Verification
- Ran `git diff --check` successfully.
- Parsed the inline script with Node successfully.
- Confirmed the branch is ahead of `main` by 1 commit and behind by 0.