### PR TITLE
Registry: add bride bank details and standardize “Puglia” casing

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
       <nav class="topnav" id="topnav">
         <a href="index.html" data-i18n="nav.home">Accueil</a>
         <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-        <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
+        <a href="localisation.html" data-i18n="nav.location">Puglia</a>
         <a href="info.html" data-i18n="nav.info">Informations</a>
         <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
         <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
@@ -148,9 +148,9 @@
           cta: 'Confirmer ma venue',
           countdown: { days: 'Jours', hours: 'Heures', minutes: 'Minutes', seconds: 'Secondes' },
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italie'},
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italie'},
           info: { title: 'Informations', text: 'Les détails pratiques seront ajoutés prochainement.' },
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Puglia', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
@@ -158,9 +158,9 @@
           cta: 'Confermare la presenza',
           countdown: { days: 'Giorni', hours: 'Ore', minutes: 'Minuti', seconds: 'Secondi' },
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italia'},
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italia'},
           info: { title: 'Informazioni', text: 'I dettagli pratici saranno aggiunti prossimamente.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
           rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
@@ -168,9 +168,9 @@
           cta: 'Confirm attendance',
           countdown: { days: 'Days', hours: 'Hours', minutes: 'Minutes', seconds: 'Seconds' },
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italy'},
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italy'},
           info: { title: 'Information', text: 'Practical details will be added soon.' },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };

--- a/info.html
+++ b/info.html
@@ -66,7 +66,7 @@
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-      <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
+      <a href="localisation.html" data-i18n="nav.location">Puglia</a>
       <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
@@ -141,7 +141,7 @@
           date: '08 août 2026 · Castello Marchione',
           cta: 'Confirmer ma venue',
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italie'},
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italie'},
           info: {
             title: 'Informations',
             intro: 'Voici quelques informations utiles pour profiter au mieux de la journée de notre mariage.',
@@ -195,14 +195,14 @@
             contactsTitle: 'Contacts',
             contactEmailLabel: 'Email :'
           },
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Puglia', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italia'},
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italia'},
           info: {
             title: 'Informazioni',
             intro: 'Ecco alcune informazioni utili per vivere al meglio la giornata del nostro matrimonio.',
@@ -256,14 +256,14 @@
             contactsTitle: 'Contatti',
             contactEmailLabel: 'Email :'
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
           rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
           cta: 'Confirm attendance',
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italy'},
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italy'},
           info: {
             title: 'Information',
             intro: 'Here is some useful information to help you make the most of our wedding day.',
@@ -317,7 +317,7 @@
             contactsTitle: 'Contacts',
             contactEmailLabel: 'Email:'
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };

--- a/liste-noce.html
+++ b/liste-noce.html
@@ -37,7 +37,7 @@
       .note{max-width:680px;margin:0 auto 18px;line-height:1.7;font-size:18px;color:var(--muted);}
       .bank-toggle{margin-top:22px;border:1px solid var(--text);background:#fff;color:var(--text);padding:12px 20px;border-radius:999px;cursor:pointer;font-size:16px;font-weight:500;transition:all .25s ease;}
       .bank-toggle:hover{background:var(--text);color:#fff;}
-      .bank-note{margin:16px auto 0;max-width:700px;padding:16px 20px;border:1px solid var(--border);border-radius:16px;background:#fff;color:var(--text);font-size:17px;line-height:1.65;}
+      .bank-note{margin:16px auto 0;max-width:700px;padding:16px 20px;border:1px solid var(--border);border-radius:16px;background:#fff;color:var(--text);font-size:17px;line-height:1.65;white-space:pre-line;}
       .hamburger{display:none;}
       @media (max-width:768px){
         .lang-switch{position:absolute; top:20px; left:16px; z-index:3;}
@@ -63,7 +63,7 @@
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-      <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
+      <a href="localisation.html" data-i18n="nav.location">Puglia</a>
       <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
@@ -74,8 +74,8 @@
         <p class="note" data-i18n="registry.text">Spoiler : il n’y en a pas. Pas de liste, pas de registre, pas de « troisième service d’assiettes qu’on n’utilisera jamais ».</p>
         <p class="note" data-i18n="registry.text2">Ce que nous voulons vraiment est simple : vous, là avec nous, en train de danser au château... et un voyage de noces incroyable.</p>
         <p class="note" data-i18n="registry.text3">Nous n’achèterons rien d’utile : seulement des couchers de soleil dans des endroits perdus, des cabanes sur la mer et des aventures dans le désert.</p>
-        <button type="button" class="bank-toggle" data-i18n="registry.bankButton">Pour celles et ceux qui souhaitent participer, voici les coordonnées de la mariée. Le compte commun arrive bientôt, mais nous sommes déjà opérationnels et, comme d’habitude, nos valises sont déjà prêtes.</button>
-        <p class="bank-note" data-i18n="registry.bankLater" hidden>Les données bancaires seront ajoutées plus tard. Merci pour votre patience et votre générosité.</p>
+        <button type="button" class="bank-toggle" data-i18n="registry.bankButton">Pour celles et ceux qui souhaitent participer, voici les coordonnées de la mariée en attendant d’avoir notre compte commun.</button>
+        <p class="bank-note" data-i18n="registry.bankLater" hidden>Fidalma INTINI<br>IBAN: IT81T0306941323100000004134<br>BIC/SWIFT: BCITITMM</p>
       </section>
     </main>
     <script>
@@ -86,10 +86,10 @@
             text: "Spoiler : il n’y en a pas. Pas de liste, pas de registre, pas de « troisième service d’assiettes qu’on n’utilisera jamais ».",
             text2: "Ce que nous voulons vraiment est simple : vous, là avec nous, en train de danser au château... et un voyage de noces incroyable.",
             text3: "Nous n’achèterons rien d’utile : seulement des couchers de soleil dans des endroits perdus, des cabanes sur la mer et des aventures dans le désert.",
-            bankButton: "Pour celles et ceux qui souhaitent participer, voici les coordonnées de la mariée. Le compte commun arrive bientôt, mais nous sommes déjà opérationnels et, comme d’habitude, nos valises sont déjà prêtes.",
-            bankLater: "Les données bancaires seront ajoutées plus tard. Merci pour votre patience et votre générosité."
+            bankButton: "Pour celles et ceux qui souhaitent participer, voici les coordonnées de la mariée en attendant d’avoir notre compte commun.",
+            bankLater: "Fidalma INTINI\nIBAN: IT81T0306941323100000004134\nBIC/SWIFT: BCITITMM"
           },
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' }
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Puglia', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' }
         },
         it: {
           registry: {
@@ -97,10 +97,10 @@
             text: "Spoiler: non c’è. Niente liste, niente registri, niente “terzo set di piatti che non useremo mai”.",
             text2: "Quello che vogliamo davvero è semplice: voi lì con noi a ballare al Castello... e un viaggio di nozze da urlo.",
             text3: "Non compreremo niente di utile: solo tramonti in posti sperduti, capanne sul mare e avventure nel deserto.",
-            bankButton: "Per chi vuole partecipare, ecco le coordinate della sposa. Il conto comune è in arrivo, ma siamo già operativi e, come al solito, abbiamo le valigie già pronte.",
-            bankLater: "I dati bancari saranno aggiunti più avanti. Grazie per la vostra pazienza e generosità."
+            bankButton: "Per chi desidera partecipare, ecco le coordinate bancarie della sposa, in attesa di avere il nostro conto comune.",
+            bankLater: "Fidalma INTINI\nIBAN: IT81T0306941323100000004134\nBIC/SWIFT: BCITITMM"
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' }
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' }
         },
         en: {
           registry: {
@@ -108,10 +108,10 @@
             text: 'Spoiler: there isn’t one. No lists, no registries, no “third set of plates we will never use”.',
             text2: 'What we truly want is simple: you there with us, dancing at the castle... and an epic honeymoon.',
             text3: 'We will not buy anything useful: only sunsets in remote places, huts by the sea, and adventures in the desert.',
-            bankButton: 'For anyone who would like to contribute, here are the bride’s bank details. The joint account is on its way, but we are already operational and, as usual, our suitcases are already packed.',
-            bankLater: 'Bank details will be added later. Thank you for your patience and generosity.'
+            bankButton: 'For anyone who would like to contribute, here are the bride’s bank details while we wait to have our joint account.',
+            bankLater: 'Fidalma INTINI\nIBAN: IT81T0306941323100000004134\nBIC/SWIFT: BCITITMM'
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' }
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' }
         }
       };
       const SUPPORTED_LANGS = Object.keys(I18N);

--- a/localisation.html
+++ b/localisation.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>PUGLIA — Fidalma & Ilyes</title>
+    <title>Puglia — Fidalma & Ilyes</title>
     <link rel="icon" type="image/svg+xml" href="olivier.svg?v=1" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -192,14 +192,14 @@
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-      <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
+      <a href="localisation.html" data-i18n="nav.location">Puglia</a>
       <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
     </nav>
     <main>
       <section id="localisation">
-        <h2 data-i18n="location.title">PUGLIA</h2>
+        <h2 data-i18n="location.title">Puglia</h2>
         <div class="puglia-intro">
           <h3 data-i18n="location.puglia.title">Les Pouilles</h3>
           <p data-i18n="location.puglia.text1">Nous sommes heureux de vous accueillir dans les Pouilles, une terre lumineuse entre soleil, oliviers, cuisine authentique, mer cristalline et villages blancs à couper le souffle.</p>
@@ -394,7 +394,7 @@
           cta: 'Confirmer ma venue',
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
           location: {
-            title: 'PUGLIA',
+            title: 'Puglia',
             puglia: {
               title: 'Les Pouilles',
               text1: 'Nous sommes heureux de vous accueillir dans les Pouilles, une terre lumineuse entre soleil, oliviers, cuisine authentique, mer cristalline et villages blancs à couper le souffle.',
@@ -471,7 +471,7 @@
               outro: 'Musique, lumières et pure énergie du sud.'
             }
           },
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Puglia', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
@@ -479,7 +479,7 @@
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
           location: {
-            title: 'PUGLIA',
+            title: 'Puglia',
             puglia: {
               title: 'La Puglia',
               text1: 'Siamo felici di accogliervi in Puglia, una terra luminosa tra sole, ulivi, cucina genuina, mare cristallino e borghi bianchi da togliere il fiato.',
@@ -556,7 +556,7 @@
               outro: 'Musica, luci e pura energia del sud.'
             }
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
           rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
@@ -564,7 +564,7 @@
           cta: 'Confirm attendance',
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
           location: {
-            title: 'PUGLIA',
+            title: 'Puglia',
             puglia: {
               title: 'Puglia',
               text1: 'We are delighted to welcome you to Puglia, a radiant land of sunshine, olive trees, authentic cuisine, crystal-clear sea and breathtaking white villages.',
@@ -641,7 +641,7 @@
               outro: 'Music, lights and pure southern energy.'
             }
           },
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };

--- a/rsvp.html
+++ b/rsvp.html
@@ -57,7 +57,7 @@
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-      <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
+      <a href="localisation.html" data-i18n="nav.location">Puglia</a>
       <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
@@ -75,24 +75,24 @@
           date: '08 août 2026 · Castello Marchione',
           cta: 'Confirmer ma venue',
           wedding: { title: 'Wedding — Déroulé', ceremony: '17h00 : Cérémonie', aperitivo: '18h00 : Aperitivo', dinner: '20h00 : Dîner', party: '23h00 : Festa & DJ set'},
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italie'},
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italie'},
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Puglia', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
           date: '08 agosto 2026 · Castello Marchione',
           cta: 'Confermare la presenza',
           wedding: { title: 'Matrimonio — Programma', ceremony: '17:00 : Cerimonia', aperitivo: '18:00 : Aperitivo', dinner: '20:00 : Cena', party: '23:00 : Festa & DJ set'},
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italia'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italia'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
           rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
           date: '08 August 2026 · Castello Marchione',
           cta: 'Confirm attendance',
           wedding: { title: 'Wedding — Schedule', ceremony: '17:00 : Ceremony', aperitivo: '18:00 : Aperitif', dinner: '20:00 : Dinner', party: '23:00 : Party & DJ set'},
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italy'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italy'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };

--- a/wedding.html
+++ b/wedding.html
@@ -131,7 +131,7 @@
     <nav class="topnav" id="topnav">
       <a href="index.html" data-i18n="nav.home">Accueil</a>
       <a href="wedding.html" data-i18n="nav.wedding">Wedding</a>
-      <a href="localisation.html" data-i18n="nav.location">PUGLIA</a>
+      <a href="localisation.html" data-i18n="nav.location">Puglia</a>
       <a href="info.html" data-i18n="nav.info">Informations</a>
       <a href="liste-noce.html" data-i18n="nav.registry">Liste de noce</a>
       <a href="rsvp.html" class="rsvp-btn" data-i18n="nav.rsvp">RSVP</a>
@@ -223,8 +223,8 @@
             party: 'Dance floor',
             party_note: 'La piste de danse sera ouverte jusqu’à 2h30.'
           },
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italie'},
-          nav: { home: 'Accueil', wedding: 'Wedding', location: 'PUGLIA', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italie'},
+          nav: { home: 'Accueil', wedding: 'Wedding', location: 'Puglia', info: 'Informations', registry: 'Liste de noce', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Merci de confirmer votre présence avant le 30 juin 2026.', cta: 'Répondre au formulaire'}
         },
         it: {
@@ -252,8 +252,8 @@
             party: 'Dance floor',
             party_note: 'La pista da ballo sarà aperta fino alle 2:30.'
           },
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italia'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italia'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Informazioni', registry: 'Lista nozze', rsvp: 'Conferma' },
           rsvp: { title: 'Conferma', text: 'Vi preghiamo di confermare entro il 30 giugno 2026.', cta: 'Rispondere al modulo'}
         },
         en: {
@@ -281,8 +281,8 @@
             party: 'Dance floor',
             party_note: 'The dance floor will be open until 2:30 AM.'
           },
-          location: { title: 'PUGLIA', text: 'Castello Marchione, Conversano, Italy'},
-          nav: { home: 'Home', wedding: 'Wedding', location: 'PUGLIA', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
+          location: { title: 'Puglia', text: 'Castello Marchione, Conversano, Italy'},
+          nav: { home: 'Home', wedding: 'Wedding', location: 'Puglia', info: 'Info', registry: 'Wedding list', rsvp: 'RSVP' },
           rsvp: { title: 'RSVP', text: 'Please confirm your presence before June 30, 2026.', cta: 'Fill out the form'}
         }
       };


### PR DESCRIPTION
### Motivation
- Provide the bride's bank details in the registry button and the expandable panel for all languages with corrected phrasing and no typos.
- Ensure the displayed bank information preserves line breaks and remains readable in the expandable area.
- Normalize the location label casing from `PUGLIA` to `Puglia` across the site for consistent presentation.

### Description
- Updated `liste-noce.html`, `index.html`, `info.html`, `localisation.html`, `rsvp.html`, and `wedding.html` to replace `PUGLIA` with `Puglia` in navigation and i18n dictionaries.
- Replaced the registry CTA copy in the I18N dictionaries and the visible button text (FR/IT/EN) with corrected formulations that match the requested wording.
- Replaced the expandable bank placeholder content with the provided account details: `Fidalma INTINI`, `IBAN: IT81T0306941323100000004134`, `BIC/SWIFT: BCITITMM` and ensured the hidden panel contains the multi-line text.
- Added `white-space: pre-line` to `.bank-note` CSS so the multi-line IBAN/BIC text renders with preserved line breaks.

### Testing
- Extracted inline scripts and ran `node --check` against each extracted script, and all checks passed.
- Ran `git diff --check` which reported no whitespace/diff problems.
- Searched the repository with `rg -n "PUGLIA"` to verify replacements and confirmed occurrences were updated to `Puglia`.
- Attempted to run headless rendering tools but no browser/renderer was present (no `chromium`/`firefox`/`wkhtmltoimage`), so visual snapshot rendering was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55fb078ba0832cb84e9b1644d94240)